### PR TITLE
ESENT Windows XP compatibility problem

### DIFF
--- a/Xbim.IO/Esent/EsentShapeGeometryCursor.cs
+++ b/Xbim.IO/Esent/EsentShapeGeometryCursor.cs
@@ -226,7 +226,7 @@ namespace Xbim.IO.Esent
 
                 //Shape data
                 columndef.coltyp = JET_coltyp.LongBinary;
-                columndef.grbit = ColumndefGrbit.ColumnNotNULL;
+                columndef.grbit = ColumndefGrbit.ColumnMaybeNull;
                 Api.JetAddColumn(sesid, tableid, colNameShapeData, columndef, null, 0, out columnid);
 
                 // The primary index is the geometry label.


### PR DESCRIPTION
This fixes the ESENT Windows XP compatibility problem mentioned in the issue:
https://github.com/xBimTeam/XbimGeometry/issues/8.
Exception message: Microsoft.Isam.Esent.Interop.EsentTaggedNotNULLException, "No non-NULL tagged columns"

The problem is due to the incorrect combination of a ESE column valueType and a column null-constraint during JetAddColumn as documented here:
https://msdn.microsoft.com/en-us/library/gg294122(v=exchg.10).aspx:
JET_bitColumnNotNULL cannot be used with tagged, Long Value (that is JET_coltypLongBinary and JET_coltypLongText), or SLV columns.
