### PR TITLE
model.InsertCopy: Issue with importing large file and EsentDatabase

### DIFF
--- a/Xbim.Cobie.nuspec
+++ b/Xbim.Cobie.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>Xbim.Cobie.4</id>
-    <version>4.0.0</version>
+    <version>4.0.1-V001</version>
     <title>xBIM Cobie for Essentials 4</title>
     <authors>xBIM team</authors>
     <owners>Steve Lockley, Martin Cerny</owners>
@@ -20,7 +20,7 @@
     <tags>COBie, BIM, IFC, IfcXml, IfcZip, COBie, Ifc4, .Net, C#, BuildingSmart</tags>
     <dependencies>
       <dependency id="NPOI" version="2.2.1" />
-      <dependency id="Xbim.Essentials.4" version="4.0.0" />
+      <dependency id="Xbim.Essentials.4" version="4.0.1-V001" />
     </dependencies>
   </metadata>
   <files>

--- a/Xbim.Cobie.nuspec
+++ b/Xbim.Cobie.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>Xbim.Cobie.4</id>
-    <version>4.0.1-V001</version>
+    <version>4.0.1-V002</version>
     <title>xBIM Cobie for Essentials 4</title>
     <authors>xBIM team</authors>
     <owners>Steve Lockley, Martin Cerny</owners>
@@ -20,7 +20,7 @@
     <tags>COBie, BIM, IFC, IfcXml, IfcZip, COBie, Ifc4, .Net, C#, BuildingSmart</tags>
     <dependencies>
       <dependency id="NPOI" version="2.2.1" />
-      <dependency id="Xbim.Essentials.4" version="4.0.1-V001" />
+      <dependency id="Xbim.Essentials.4" version="4.0.1-V002" />
     </dependencies>
   </metadata>
   <files>

--- a/Xbim.Essentials.nuspec
+++ b/Xbim.Essentials.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>Xbim.Essentials.4</id>
-    <version>4.0.1-V001</version>
+    <version>4.0.1-V002</version>
     <title>xBIM Essentials 4</title>
     <authors>xBIM Team</authors>
     <owners>Steve Lockley, Martin Cerny</owners>

--- a/Xbim.Essentials.nuspec
+++ b/Xbim.Essentials.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>Xbim.Essentials.4</id>
-    <version>4.0.0</version>
+    <version>4.0.1-V001</version>
     <title>xBIM Essentials 4</title>
     <authors>xBIM Team</authors>
     <owners>Steve Lockley, Martin Cerny</owners>

--- a/Xbim.IO.TableStore/ClassMapping.cs
+++ b/Xbim.IO.TableStore/ClassMapping.cs
@@ -124,7 +124,7 @@ namespace Xbim.IO.TableStore
                         yield return mapping;
                         continue;
                     }
-                    if (mType.SubTypes != null && mType.SubTypes.Contains(type))
+                    if (mType.AllSubTypes.Contains(type))
                     {
                         yield return mapping;
                     }


### PR DESCRIPTION
Find attached a Unit test which copies from a Autodesk Inventor generated IFC file the IfcShapreRepresentation into a new model. The test fails on EsentDatabase if Inventor IFC has a certain size - The new saved model gets missing STEP file references.  It works on InMemory database

[Ifc2x3InsertCopyTest.zip](https://github.com/xBimTeam/XbimEssentials/files/551164/Ifc2x3InsertCopyTest.zip)

