### PR TITLE
Fix wexbim export error when only one instance is left after filter

### DIFF
--- a/Xbim.Ifc/IfcStore.cs
+++ b/Xbim.Ifc/IfcStore.cs
@@ -1091,19 +1091,19 @@ namespace Xbim.Ifc
                 {
                     if (geometry.ShapeData.Length <= 0) //no geometry to display so don't write out any products for it
                         continue;
-                    if (geometry.ReferenceCount > 1)
+                    var instances = geomRead.ShapeInstancesOfGeometry(geometry.ShapeLabel);
+
+
+
+                    var xbimShapeInstances = instances.Where(si => !toIgnore.Contains(si.IfcTypeId) &&
+                                                                 si.RepresentationType ==
+                                                                 XbimGeometryRepresentationType
+                                                                     .OpeningsAndAdditionsIncluded && prodIds.Contains(si.IfcProductLabel)).ToList();
+                    if (!xbimShapeInstances.Any()) continue;
+                    numberOfGeometries++;
+                    binaryStream.Write(xbimShapeInstances.Count); //the number of repetitions of the geometry
+                    if (xbimShapeInstances.Count > 1)
                     {
-                        var instances = geomRead.ShapeInstancesOfGeometry(geometry.ShapeLabel);
-
-
-
-                        var xbimShapeInstances = instances.Where(si => !toIgnore.Contains(si.IfcTypeId) &&
-                                                                     si.RepresentationType ==
-                                                                     XbimGeometryRepresentationType
-                                                                         .OpeningsAndAdditionsIncluded && prodIds.Contains(si.IfcProductLabel)).ToList();
-                        if (!xbimShapeInstances.Any()) continue;
-                        numberOfGeometries++;
-                        binaryStream.Write(xbimShapeInstances.Count); //the number of repetitions of the geometry
                         foreach (IXbimShapeInstanceData xbimShapeInstance in xbimShapeInstances)
                         //write out each of the ids style and transforms
                         {
@@ -1127,17 +1127,11 @@ namespace Xbim.Ifc
 
                         tr.Write(binaryStream);
                     }
-                    else if (geometry.ReferenceCount == 1)//now do the single instances
+                    else //now do the single instances
                     {
-                        var xbimShapeInstance = geomRead.ShapeInstancesOfGeometry(geometry.ShapeLabel).FirstOrDefault();
-
-                        if (xbimShapeInstance == null || toIgnore.Contains(xbimShapeInstance.IfcTypeId) ||
-                            xbimShapeInstance.RepresentationType != XbimGeometryRepresentationType.OpeningsAndAdditionsIncluded || !prodIds.Contains(xbimShapeInstance.IfcProductLabel))
-                            continue;
-                        numberOfGeometries++;
+                        var xbimShapeInstance = xbimShapeInstances[0];
 
                         // IXbimShapeGeometryData geometry = ShapeGeometry(kv.Key);
-                        binaryStream.Write((Int32)1); //the number of repetitions of the geometry (1)
                         binaryStream.Write((Int32)xbimShapeInstance.IfcProductLabel);
                         binaryStream.Write((UInt16)xbimShapeInstance.IfcTypeId);
                         binaryStream.Write((Int32)xbimShapeInstance.InstanceLabel);


### PR DESCRIPTION
When saving a wexbim file, in the shapeinstances region, once the filter is applied, if only one instance remains, the shape instance would be saved using the "multiple instance" scheme, being vertices and transform matrix.  When reading the file, it would be indistinguishable from the "normal" single instance scheme where the transform matrix is baked in the vertices.  This resulted in an offset in the read bytestream, causing un-readable file or sometimes corrupted display.