### PR TITLE
Tessellation was done in floats, resulting in loss of precision.

### DIFF
--- a/Xbim.Common/XbimExtensions/BinaryReaderExtensions.cs
+++ b/Xbim.Common/XbimExtensions/BinaryReaderExtensions.cs
@@ -20,7 +20,7 @@ namespace Xbim.Common.XbimExtensions
 
             for (var i = 0; i < numVertices; i++)
             {
-                vertices.Add(br.ReadPointFloat3D());
+                vertices.Add(br.ReadPoint3D());
             }
             var numFaces = br.ReadInt32();
             var faces = new List<XbimFaceTriangulation>(numFaces);
@@ -77,6 +77,14 @@ namespace Xbim.Common.XbimExtensions
             double y = br.ReadSingle();
             double z = br.ReadSingle();
             return new XbimPoint3D(x,y,z);
+        }
+
+        public static XbimPoint3D ReadPoint3D(this BinaryReader br)
+        {
+            double x = br.ReadDouble();
+            double y = br.ReadDouble();
+            double z = br.ReadDouble();
+            return new XbimPoint3D(x, y, z);
         }
 
         public static XbimPackedNormal ReadPackedNormal(this BinaryReader br)

--- a/Xbim.Tessellator/Geom.cs
+++ b/Xbim.Tessellator/Geom.cs
@@ -84,12 +84,12 @@ namespace Xbim.Tessellator
         /// let r be the negated result (this evaluates (uw)(v->s)), then
         /// r is guaranteed to satisfy MIN(u->t,w->t) less than or equal r less than or equal MAX(u->t,w->t).
         /// </summary>
-        public static float EdgeEval(MeshUtils.Vertex u, MeshUtils.Vertex v, MeshUtils.Vertex w)
+        public static double EdgeEval(MeshUtils.Vertex u, MeshUtils.Vertex v, MeshUtils.Vertex w)
         {
             Debug.Assert(VertLeq(u, v) && VertLeq(v, w));
 
-            float gapL = v._s - u._s;
-            float gapR = w._s - v._s;
+            double gapL = v._s - u._s;
+            double gapR = w._s - v._s;
 
             if (gapL + gapR > 0.0f)
             {
@@ -106,12 +106,12 @@ namespace Xbim.Tessellator
         /// is cheaper to evaluate. Returns > 0, == 0 , or less than 0
         /// as v is above, on, or below the edge uw.
         /// </summary>
-        public static float EdgeSign(MeshUtils.Vertex u, MeshUtils.Vertex v, MeshUtils.Vertex w)
+        public static double EdgeSign(MeshUtils.Vertex u, MeshUtils.Vertex v, MeshUtils.Vertex w)
         {
           //  Debug.Assert(VertLeq(u, v) && VertLeq(v, w));
 
-            float gapL = v._s - u._s;
-            float gapR = w._s - v._s;
+            double gapL = v._s - u._s;
+            double gapR = w._s - v._s;
 
             if (gapL + gapR > 0.0f)
             {
@@ -130,12 +130,12 @@ namespace Xbim.Tessellator
 // ReSharper restore CompareOfFloatsByEqualityOperator
         }
 
-        public static float TransEval(MeshUtils.Vertex u, MeshUtils.Vertex v, MeshUtils.Vertex w)
+        public static double TransEval(MeshUtils.Vertex u, MeshUtils.Vertex v, MeshUtils.Vertex w)
         {
             Debug.Assert(TransLeq(u, v) && TransLeq(v, w));
 
-            float gapL = v._t - u._t;
-            float gapR = w._t - v._t;
+            double gapL = v._t - u._t;
+            double gapR = w._t - v._t;
 
             if (gapL + gapR > 0.0f)
             {
@@ -147,12 +147,12 @@ namespace Xbim.Tessellator
             return 0.0f;
         }
 
-        public static float TransSign(MeshUtils.Vertex u, MeshUtils.Vertex v, MeshUtils.Vertex w)
+        public static double TransSign(MeshUtils.Vertex u, MeshUtils.Vertex v, MeshUtils.Vertex w)
         {
             Debug.Assert(TransLeq(u, v) && TransLeq(v, w));
 
-            float gapL = v._t - u._t;
-            float gapR = w._t - v._t;
+            double gapL = v._t - u._t;
+            double gapR = w._t - v._t;
 
             if (gapL + gapR > 0.0f)
             {
@@ -174,7 +174,7 @@ namespace Xbim.Tessellator
             return VertLeq(e._Org, e.Dst);
         }
 
-        public static float VertL1Dist(MeshUtils.Vertex u, MeshUtils.Vertex v)
+        public static double VertL1Dist(MeshUtils.Vertex u, MeshUtils.Vertex v)
         {
             return Math.Abs(u._s - v._s) + Math.Abs(u._t - v._t);
         }
@@ -185,7 +185,7 @@ namespace Xbim.Tessellator
             eDst._Sym._winding += eSrc._Sym._winding;
         }
 
-        public static float Interpolate(float a, float x, float b, float y)
+        public static double Interpolate(double a, double x, double b, double y)
         {
             a = a < 0.0f ? 0.0f : a;
             b = b < 0.0f ? 0.0f : b;
@@ -210,7 +210,7 @@ namespace Xbim.Tessellator
         /// </summary>
         public static void EdgeIntersect(MeshUtils.Vertex o1, MeshUtils.Vertex d1, MeshUtils.Vertex o2, MeshUtils.Vertex d2, MeshUtils.Vertex v)
         {
-            float z1, z2;
+            double z1, z2;
 
             // This is certainly not the most efficient way to find the intersection
             // of two line segments, but it is very numerically stable.

--- a/Xbim.Tessellator/MeshUtils.cs
+++ b/Xbim.Tessellator/MeshUtils.cs
@@ -90,7 +90,7 @@ namespace Xbim.Tessellator
     {
         public readonly static Vec3 Zero = new Vec3();
 
-        public float X, Y, Z;
+        public double X, Y, Z;
 
 
         public static bool Colinear( Vec3 a,  Vec3 b,  Vec3 c)
@@ -120,7 +120,7 @@ namespace Xbim.Tessellator
             Z = (float)z;
         }
 
-        public float this[int index]
+        public double this[int index]
         {
             get
             {
@@ -158,7 +158,7 @@ namespace Xbim.Tessellator
         }
         public static double Angle(ref Vec3 v1, ref Vec3 v2)
         {
-            float cosinus;
+            double cosinus;
             Dot(ref v1, ref v2, out cosinus);
             if (cosinus > -0.70710678118655 && cosinus < 0.70710678118655)
                 return Math.Acos(cosinus);
@@ -183,14 +183,14 @@ namespace Xbim.Tessellator
             }
         }
 
-        public float Length2
+        public double Length2
         {
             get
             {
                 return X * X + Y * Y + Z * Z;
             }
         }
-        public static void Dot(ref Vec3 u, ref Vec3 v, out float dot)
+        public static void Dot(ref Vec3 u, ref Vec3 v, out double dot)
         {
             dot = u.X * v.X + u.Y * v.Y + u.Z * v.Z;
         }
@@ -204,7 +204,7 @@ namespace Xbim.Tessellator
 
         public static bool Normalize(ref Vec3 v)
         {
-            float len = v.X * v.X + v.Y * v.Y + v.Z * v.Z;
+            double len = v.X * v.X + v.Y * v.Y + v.Z * v.Z;
             if(len <= 0.0f) return false;
             len = 1.0f / (float)Math.Sqrt(len);
             v.X *= len;
@@ -231,7 +231,7 @@ namespace Xbim.Tessellator
             internal Vertex _prev, _next;
             internal Edge _anEdge;
             internal Vec3 _coords;
-            internal float _s, _t;
+            internal double _s, _t;
             internal PqHandle _pqHandle;
             internal int _n;
             internal int _data;

--- a/Xbim.Tessellator/Sweep.cs
+++ b/Xbim.Tessellator/Sweep.cs
@@ -339,7 +339,7 @@ namespace Xbim.Tessellator
         /// splits the weight between its org and dst according to the
         /// relative distance to "isect".
         /// </summary>
-        private void VertexWeights(MeshUtils.Vertex isect, MeshUtils.Vertex org, MeshUtils.Vertex dst, out float w0, out float w1)
+        private void VertexWeights(MeshUtils.Vertex isect, MeshUtils.Vertex org, MeshUtils.Vertex dst, out double w0, out double w1)
         {
             var t1 = Geom.VertL1Dist(org, isect);
             var t2 = Geom.VertL1Dist(dst, isect);
@@ -360,7 +360,7 @@ namespace Xbim.Tessellator
         private void GetIntersectData(MeshUtils.Vertex isect, MeshUtils.Vertex orgUp, MeshUtils.Vertex dstUp, MeshUtils.Vertex orgLo, MeshUtils.Vertex dstLo)
         {
             isect._coords = Vec3.Zero;
-            float w0, w1, w2, w3;
+            double w0, w1, w2, w3;
             VertexWeights(isect, orgUp, dstUp, out w0, out w1);
             VertexWeights(isect, orgLo, dstLo, out w2, out w3);
 
@@ -1011,7 +1011,7 @@ namespace Xbim.Tessellator
         /// We add two sentinel edges above and below all other edges,
         /// to avoid special cases at the top and bottom.
         /// </summary>
-        private void AddSentinel(float smin, float smax, float t)
+        private void AddSentinel(double smin, double smax, double t)
         {
             var e = _mesh.MakeEdge();
             e._Org._s = smax;

--- a/Xbim.Tessellator/Tess.cs
+++ b/Xbim.Tessellator/Tess.cs
@@ -78,7 +78,7 @@ namespace Xbim.Tessellator
         }
     }
 
-    public delegate int CombineCallback(Vec3 position, int[] data, float[] weights);
+    public delegate int CombineCallback(Vec3 position, int[] data, double[] weights);
 
     public partial class Tess
     {
@@ -87,7 +87,7 @@ namespace Xbim.Tessellator
         private Vec3 _sUnit;
         private Vec3 _tUnit;
 
-        private float _bminX, _bminY, _bmaxX, _bmaxY;
+        private double _bminX, _bminY, _bmaxX, _bmaxY;
 
         private WindingRule _windingRule;
 
@@ -160,7 +160,7 @@ namespace Xbim.Tessellator
 
             // Look for a third vertex which forms the triangle with maximum area
             // (Length of normal == twice the triangle area)
-            float maxLen2 = 0.0f, tLen2;
+            double maxLen2 = 0.0f, tLen2;
             var v1 = minVert[i];
             var v2 = maxVert[i];
             Vec3 d1, d2, tNorm;
@@ -190,7 +190,7 @@ namespace Xbim.Tessellator
 
         public static void ComputeNewellsNormal(ContourVertex[] vertices, ref Vec3 normal)
         {
-            float x = 0, y = 0, z = 0;
+            double x = 0, y = 0, z = 0;
             ContourVertex current;
             var previous = new ContourVertex();
             int count = 0;
@@ -203,12 +203,12 @@ namespace Xbim.Tessellator
                     current = vertices[0];
                 if (count > 0)
                 {
-                    float xn = previous.Position.X;
-                    float yn = previous.Position.Y;
-                    float zn = previous.Position.Z;
-                    float xn1 = current.Position.X;
-                    float yn1 = current.Position.Y;
-                    float zn1 = current.Position.Z;
+                    double xn = previous.Position.X;
+                    double yn = previous.Position.Y;
+                    double zn = previous.Position.Z;
+                    double xn1 = current.Position.X;
+                    double yn1 = current.Position.Y;
+                    double zn1 = current.Position.Z;
                     x += (yn - yn1) * (zn + zn1);
                     y += (xn + xn1) * (zn - zn1);
                     z += (xn - xn1) * (yn + yn1);
@@ -226,7 +226,7 @@ namespace Xbim.Tessellator
         {
             // When we compute the normal automatically, we choose the orientation
             // so that the the sum of the signed areas of all contours is non-negative.
-            float area = 0.0f;
+            double area = 0.0f;
             for (var f = _mesh._fHead._next; f != _mesh._fHead; f = f._next)
             {
                 var e = f._anEdge;
@@ -636,9 +636,9 @@ namespace Xbim.Tessellator
 
        
 
-        private float SignedArea(ContourVertex[] vertices)
+        private double SignedArea(ContourVertex[] vertices)
         {
-            float area = 0.0f;
+            double area = 0.0f;
 
             for (int i = 0; i < vertices.Length; i++)
             {
@@ -665,10 +665,10 @@ namespace Xbim.Tessellator
             ContourVertex[] outer = contours[0];
             if (contours.Count > 1)
             {
-                float largestArea = Math.Abs(SignedArea(contours[0]));
+                double largestArea = Math.Abs(SignedArea(contours[0]));
                 for (int i = 1; i < contours.Count; i++)
                 {
-                    float area = Math.Abs(SignedArea(contours[i]));
+                    double area = Math.Abs(SignedArea(contours[i]));
                     if (area > largestArea)
                     {
                         largestArea = area;
@@ -699,7 +699,7 @@ namespace Xbim.Tessellator
             bool reverse = false;
             if (forceOrientation != ContourOrientation.Original)
             {
-                float area = SignedArea(vertices);
+                double area = SignedArea(vertices);
                 reverse = (forceOrientation == ContourOrientation.Clockwise && area < 0.0f) || (forceOrientation == ContourOrientation.CounterClockwise && area > 0.0f);
             }
 


### PR DESCRIPTION
Tessellation was done in floats, resulting in loss of precision.
Troublesome in very large projects where units are millimeters.

Before :
![image](https://user-images.githubusercontent.com/20001753/30070331-1d26174e-9231-11e7-8a2f-1949800d37b6.png)

After :
![image](https://user-images.githubusercontent.com/20001753/30070370-2fdee820-9231-11e7-9a5b-cc9d1dff9a97.png)
