### PR TITLE
Fix #107 - Errors tolerance for loading "bad" files is increased

### DIFF
--- a/Xbim.IO/Memory/MemoryModel.cs
+++ b/Xbim.IO/Memory/MemoryModel.cs
@@ -510,7 +510,15 @@ namespace Xbim.IO.Memory
                     }
                 }
 
-                var typeId = Metadata.ExpressTypeId(name);
+                // ignore entities of unknown type instead of throwing fatal exception
+                var type = Metadata.ExpressType(name);
+                if (null == type)
+                {
+                    Log.Error(string.Format("Error in file at label {0} for type {1} - type is unknown", label, name));
+                    return null;
+                }
+
+                var typeId = type.TypeId;
                 var ent = _instances.Factory.New(this, typeId, (int)label, true);
 
                 // if entity is null do not add so that the file load operation can survive an illegal entity

--- a/Xbim.IO/Step21/XbimP21Parser.cs
+++ b/Xbim.IO/Step21/XbimP21Parser.cs
@@ -217,6 +217,12 @@ namespace Xbim.IO.Step21
 
         protected override void EndEntity()
         {
+            // Check if stack is empty to avoid exception
+            if (0 == _processStack.Count)
+            {
+                Logger.Error("Stack is empty");
+                return;
+            }
             var p21 = _processStack.Pop();
             //Debug.Assert(_processStack.Count == 0);
             CurrentInstance = null;


### PR DESCRIPTION
This commit fixes two exceptions that prevented mentioned files to be loaded

1) MemoryModel.cs - Fix of NullReferenceException when trying to get type ID for unrecognized (bad) entity type
2) XbimP21Parser.cs - Avoid InvalidOperationException when _processStack is empty that occurs when EndEntity() is called after handling error.

Fix https://github.com/xBimTeam/XbimEssentials/issues/107
