### PR TITLE
Making fallback product type colours configurable

### DIFF
--- a/Xbim.Ifc/Xbim.Ifc.csproj
+++ b/Xbim.Ifc/Xbim.Ifc.csproj
@@ -52,6 +52,9 @@
       <HintPath>..\packages\log4net.2.0.8\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -84,6 +87,7 @@
     <Compile Include="ViewModels\XbimModelViewModel.cs" />
     <Compile Include="ViewModels\XbimRefModelViewModel.cs" />
     <Compile Include="XbimColour.cs" />
+    <Compile Include="XbimColourDTO.cs" />
     <Compile Include="XbimColourMap.cs" />
     <Compile Include="XbimEditorCredentials.cs" />
     <Compile Include="XbimModelType.cs" />

--- a/Xbim.Ifc/XbimColourDTO.cs
+++ b/Xbim.Ifc/XbimColourDTO.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+
+namespace Xbim.Ifc
+{
+    public class XbimColourDTO
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("red")]
+        public double Red { get; set; }
+
+        [JsonProperty("green")]
+        public double Green { get; set; }
+
+        [JsonProperty("blue")]
+        public double Blue { get; set; }
+
+        [JsonProperty("alpha")]
+        public double Alpha { get; set; }
+
+        public XbimColour ToXbimColour()
+        {
+            return new XbimColour(Name, Red, Green, Blue, Alpha);
+        }
+    }
+}

--- a/Xbim.Ifc/XbimColourMap.cs
+++ b/Xbim.Ifc/XbimColourMap.cs
@@ -1,5 +1,12 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
+using System.Reflection;
+
+using Newtonsoft.Json;
+
 using Xbim.Ifc4.Interfaces;
 
 namespace Xbim.Ifc
@@ -26,6 +33,7 @@ namespace Xbim.Ifc
    
     public class XbimColourMap : KeyedCollection<string, XbimColour>
     {
+        private const string ProductTypeDefaultColoursConfigPath = "ProductTypeDefaultColours.json";
 
         public override int GetHashCode()
         {
@@ -129,31 +137,49 @@ namespace Xbim.Ifc
         /// </summary>
         public void SetProductTypeColourMap()
         {
+            try
+            {
+                SetProductTypeColourMapFromConfig();
+            }
+            catch (Exception)
+            {
+                Clear();
+                Add(new XbimColour("Default", 0.98, 0.92, 0.74));
+                Add(new XbimColour("IfcWall", 0.98, 0.92, 0.74));
+                Add(new XbimColour("IfcWallStandardCase", 0.98, 0.92, 0.74));
+                Add(new XbimColour("IfcRoof", 0.28, 0.24, 0.55));
+                Add(new XbimColour("IfcBeam", 0.0, 0.0, 0.55));
+                Add(new XbimColour("IfcBuildingElementProxy", 0.95, 0.94, 0.74));
+                Add(new XbimColour("IfcColumn", 0.0, 0.0, 0.55));
+                Add(new XbimColour("IfcSlab", 0.47, 0.53, 0.60));
+                Add(new XbimColour("IfcWindow", 0.68, 0.85, 0.90, 0.5));
+                Add(new XbimColour("IfcCurtainWall", 0.68, 0.85, 0.90, 0.4));
+                Add(new XbimColour("IfcPlate", 0.68, 0.85, 0.90, 0.4));
+                Add(new XbimColour("IfcDoor", 0.97, 0.19, 0));
+                Add(new XbimColour("IfcSpace", 0.68, 0.85, 0.90, 0.4));
+                Add(new XbimColour("IfcMember", 0.34, 0.34, 0.34));
+                Add(new XbimColour("IfcDistributionElement", 0.0, 0.0, 0.55));
+                Add(new XbimColour("IfcFurnishingElement", 1, 0, 0));
+                Add(new XbimColour("IfcOpeningElement", 0.2, 0.2, 0.8, 0.2));
+                Add(new XbimColour("IfcFeatureElementSubtraction", 1.0, 1.0, 1.0));
+                Add(new XbimColour("IfcFlowTerminal", 0.95, 0.94, 0.74));
+                Add(new XbimColour("IfcFlowSegment", 0.95, 0.94, 0.74));
+                Add(new XbimColour("IfcDistributionFlowElement", 0.95, 0.94, 0.74));
+                Add(new XbimColour("IfcFlowFitting", 0.95, 0.94, 0.74));
+                Add(new XbimColour("IfcRailing", 0.95, 0.94, 0.74));
+                Add(new XbimColour("IfcGrid", 1.0, 0.9, 0));
+            }
+        }
+
+        private void SetProductTypeColourMapFromConfig()
+        {
+            string assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string configFile = Path.Combine(assemblyFolder ?? string.Empty, ProductTypeDefaultColoursConfigPath);
+            string json = File.ReadAllText(configFile);
+            var productTypeDefaultXbimColours = JsonConvert.DeserializeObject<List<XbimColourDTO>>(json);
+
             Clear();
-            Add(new XbimColour("Default", 0.98, 0.92, 0.74));
-            Add(new XbimColour("IfcWall", 0.98, 0.92, 0.74));
-            Add(new XbimColour("IfcWallStandardCase", 0.98, 0.92, 0.74));
-            Add(new XbimColour("IfcRoof", 0.28, 0.24, 0.55));
-            Add(new XbimColour("IfcBeam", 0.0, 0.0, 0.55));
-            Add(new XbimColour("IfcBuildingElementProxy", 0.95, 0.94, 0.74));
-            Add(new XbimColour("IfcColumn", 0.0, 0.0, 0.55));
-            Add(new XbimColour("IfcSlab", 0.47, 0.53, 0.60));
-            Add(new XbimColour("IfcWindow", 0.68, 0.85, 0.90, 0.5));
-            Add(new XbimColour("IfcCurtainWall", 0.68, 0.85, 0.90, 0.4));
-            Add(new XbimColour("IfcPlate", 0.68, 0.85, 0.90, 0.4));
-            Add(new XbimColour("IfcDoor", 0.97, 0.19, 0));
-            Add(new XbimColour("IfcSpace", 0.68, 0.85, 0.90, 0.4));
-            Add(new XbimColour("IfcMember", 0.34, 0.34, 0.34));
-            Add(new XbimColour("IfcDistributionElement", 0.0, 0.0, 0.55));
-            Add(new XbimColour("IfcFurnishingElement", 1, 0, 0));
-            Add(new XbimColour("IfcOpeningElement", 0.2, 0.2, 0.8, 0.2));
-            Add(new XbimColour("IfcFeatureElementSubtraction", 1.0, 1.0, 1.0));
-            Add(new XbimColour("IfcFlowTerminal", 0.95, 0.94, 0.74));
-            Add(new XbimColour("IfcFlowSegment", 0.95, 0.94, 0.74));
-            Add(new XbimColour("IfcDistributionFlowElement", 0.95, 0.94, 0.74));
-            Add(new XbimColour("IfcFlowFitting", 0.95, 0.94, 0.74));
-            Add(new XbimColour("IfcRailing", 0.95, 0.94, 0.74));
-            Add(new XbimColour("IfcGrid", 1.0, 0.9, 0));
+            productTypeDefaultXbimColours.ForEach(x => Add(x.ToXbimColour()));
         }
     }
 }

--- a/Xbim.Ifc/packages.config
+++ b/Xbim.Ifc/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net40" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
First of all thank you for your work. 
I received a request from my product owner to override the default IFC product type colours, so I thought it would be nice if it could become configurable. Nothing fancy here, a simple json file that would need to be added into the assembly folder of your project(basically where the xbim.ifc dll lives), have the name "ProductTypeDefaultColours.json" and have the following format:  `[
  {
    "name": "Default",
    "red": 0,
    "green": 0,
    "blue": 1,
    "alpha": 1
  },
  {
    "name": "IfcWall",
    "red": 0,
    "green": 0,
    "blue": 1,
    "alpha": 1
  },
...]`.

Conversion is done with Newtonsoft Json.NET.  In case where no file is found or any exception of any kind, we simply default to the original mapping. 
This seems like the best solution for our needs at the moment, and I'm hoping it could benefit others as well.
**Cheers!** 