### PR TITLE
[FIXED] Fix issue on IfcDuration float parsing due to Culture

### DIFF
--- a/Xbim.Ifc4/DateTimeResource/IfcDurationPartial.cs
+++ b/Xbim.Ifc4/DateTimeResource/IfcDurationPartial.cs
@@ -114,7 +114,7 @@ namespace Xbim.Ifc4.DateTimeResource
                 if (span.Seconds != 0 || span.Milliseconds != 0)
                 {
                     var value = Math.Abs(span.Seconds) + Math.Abs(span.Milliseconds) / 1000f;
-                    sb.Append(value.ToString("F3"));
+                    sb.Append(value.ToString("F3",CultureInfo.InvariantCulture));
                     sb.Append('S');
                 }
             }


### PR DESCRIPTION
Fix issue on Culture with floating point value.
Bug in a larger scope, why don't use the CultureInfo.Invariant everywhere instead of create each time this : 

`private static readonly System.Globalization.CultureInfo Culture =
	        System.Globalization.CultureInfo.CreateSpecificCulture("en-US");`

CultureInfo.Invariant is independant from culture and will always reach what you want for formatting bim files it's really much cleaner than create an English culture.