### PR TITLE
Add Imperial Unit/U.S CustomaryUnit (currently the same) during IfcProject initialization with SI and conversion unit. 

### DIFF
--- a/Xbim.Common/ProjectUnits.cs
+++ b/Xbim.Common/ProjectUnits.cs
@@ -5,6 +5,8 @@
     /// </summary>
     public enum ProjectUnits
     {
-        SIUnitsUK
-    }
+		SIUnitsUK,
+		ImperialUnits,
+		USCustomaryUnits
+	}
 }

--- a/Xbim.Ifc2x3/Kernel/IfcProjectPartial.cs
+++ b/Xbim.Ifc2x3/Kernel/IfcProjectPartial.cs
@@ -8,269 +8,247 @@ using Xbim.Ifc2x3.ProductExtension;
 
 namespace Xbim.Ifc2x3.Kernel
 {
-    public partial class IfcProject
-    {
-        public IfcGeometricRepresentationContext ModelContext
-        {
-            get
-            {
-                return 
-                    RepresentationContexts.
-                        FirstOrDefault<IfcGeometricRepresentationContext>(r => r.ContextType == "Model");    
-            }
-            
-        }
+	public partial class IfcProject
+	{
+		public IfcGeometricRepresentationContext ModelContext
+		{
+			get
+			{
+				return
+					RepresentationContexts.
+						FirstOrDefault<IfcGeometricRepresentationContext>(r => r.ContextType == "Model");
+			}
 
-        /// <summary>
-        ///   Sets up the default units as SI
-        ///   Creates the GeometricRepresentationContext for a Model view, required by Ifc compliance
-        /// </summary>
-        public void Initialize(ProjectUnits units)
-        {
-            var model = Model;
-            if (units == ProjectUnits.SIUnitsUK)
-            {
-                var ua = model.Instances.New<IfcUnitAssignment>();
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.LENGTHUNIT;
-                    s.Name = IfcSIUnitName.METRE;
-                    s.Prefix = IfcSIPrefix.MILLI;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.AREAUNIT;
-                    s.Name = IfcSIUnitName.SQUARE_METRE;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.VOLUMEUNIT;
-                    s.Name = IfcSIUnitName.CUBIC_METRE;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.SOLIDANGLEUNIT;
-                    s.Name = IfcSIUnitName.STERADIAN;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.PLANEANGLEUNIT;
-                    s.Name = IfcSIUnitName.RADIAN;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.MASSUNIT;
-                    s.Name = IfcSIUnitName.GRAM;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.TIMEUNIT;
-                    s.Name = IfcSIUnitName.SECOND;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType =
-                        IfcUnitEnum.THERMODYNAMICTEMPERATUREUNIT;
-                    s.Name = IfcSIUnitName.DEGREE_CELSIUS;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.LUMINOUSINTENSITYUNIT;
-                    s.Name = IfcSIUnitName.LUMEN;
-                }));
-                UnitsInContext = ua;
-            }
-            //Create the Mandatory Model View
-            if (ModelContext == null)
-            {
-                var origin = model.Instances.New<IfcCartesianPoint>(p => p.SetXYZ(0, 0, 0));
-                var axis3D = model.Instances.New<IfcAxis2Placement3D>(a => a.Location = origin);
-                var gc = model.Instances.New<IfcGeometricRepresentationContext>(c =>
-                {
-                    c.
-                        ContextType
-                        =
-                        "Model";
-                    c.
-                        ContextIdentifier
-                        =
-                        "Building Model";
-                    c.
-                        CoordinateSpaceDimension
-                        = 3;
-                    c.Precision
-                        =
-                        0.00001;
-                    c.
-                        WorldCoordinateSystem
-                        = axis3D;
-                }
-                    );
-                RepresentationContexts.Add(gc);
+		}
 
-                var origin2D = model.Instances.New<IfcCartesianPoint>(p => p.SetXY(0, 0));
-                var axis2D = model.Instances.New<IfcAxis2Placement2D>(a => a.Location = origin2D);
-                var pc = model.Instances.New<IfcGeometricRepresentationContext>(c =>
-                {
-                    c.
-                        ContextType
-                        =
-                        "Plan";
-                    c.
-                        ContextIdentifier
-                        =
-                        "Building Plan View";
-                    c.
-                        CoordinateSpaceDimension
-                        = 2;
-                    c.Precision
-                        =
-                        0.00001;
-                    c.
-                        WorldCoordinateSystem
-                        = axis2D;
-                }
-                    );
-                RepresentationContexts.Add(pc);
+		/// <summary>
+		///   Sets up the default units as SI
+		///   Creates the GeometricRepresentationContext for a Model view, required by Ifc compliance
+		/// </summary>
+		public void Initialize(ProjectUnits units)
+		{
+			var model = Model;
+			var ua = model.Instances.New<IfcUnitAssignment>();
 
-            }
-        }
+			if (units == ProjectUnits.SIUnitsUK)
+			{
+				ua.SetOrChangeSiUnit(IfcUnitEnum.LENGTHUNIT, IfcSIUnitName.METRE, IfcSIPrefix.MILLI);
+				ua.SetOrChangeSiUnit(IfcUnitEnum.AREAUNIT, IfcSIUnitName.SQUARE_METRE, null);
+				ua.SetOrChangeSiUnit(IfcUnitEnum.VOLUMEUNIT, IfcSIUnitName.CUBIC_METRE, null);
+				ua.SetOrChangeSiUnit(IfcUnitEnum.MASSUNIT, IfcSIUnitName.GRAM, IfcSIPrefix.KILO);
+			}
+			else if (units == ProjectUnits.ImperialUnits || units == ProjectUnits.USCustomaryUnits)
+			{
+				ua.SetOrChangeConversionUnit(IfcUnitEnum.LENGTHUNIT, ConversionBasedUnit.Foot);
+				ua.SetOrChangeConversionUnit(IfcUnitEnum.AREAUNIT, ConversionBasedUnit.SquareFoot);
+				ua.SetOrChangeConversionUnit(IfcUnitEnum.VOLUMEUNIT, ConversionBasedUnit.CubicFoot);
+				ua.SetOrChangeConversionUnit(IfcUnitEnum.MASSUNIT, ConversionBasedUnit.Pound);
+			}
 
-        /// <summary>
-        /// Returns all buildings at the highest level of spatial structural decomposition (i.e. root buildings)
-        /// </summary>
-        public IEnumerable<Xbim.Ifc4.Interfaces.IIfcBuilding> Buildings
-        {
-            get
-            {
-                IEnumerable<IfcRelAggregates> aggregate = IsDecomposedBy.OfType<IfcRelAggregates>();
-                foreach (IfcRelAggregates rel in aggregate)
-                {
-                    foreach (IfcObjectDefinition definition in rel.RelatedObjects)
-                    {
-                        var site = definition as IfcSite;
-                        if (site != null)
-                            foreach (var building in site.Buildings)
-                                yield return building;
-                        if (definition is IfcBuilding)
-                            yield return (definition as IfcBuilding);
-                    }
-                }
-            }
-        }
+			ua.SetOrChangeSiUnit(IfcUnitEnum.SOLIDANGLEUNIT, IfcSIUnitName.STERADIAN, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.PLANEANGLEUNIT, IfcSIUnitName.RADIAN, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.TIMEUNIT, IfcSIUnitName.SECOND, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.THERMODYNAMICTEMPERATUREUNIT, IfcSIUnitName.KELVIN, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.THERMODYNAMICTEMPERATUREUNIT, IfcSIUnitName.DEGREE_CELSIUS, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.POWERUNIT, IfcSIUnitName.WATT, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.FORCEUNIT, IfcSIUnitName.NEWTON, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.ILLUMINANCEUNIT, IfcSIUnitName.LUX, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.LUMINOUSFLUXUNIT, IfcSIUnitName.LUMEN, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.LUMINOUSINTENSITYUNIT, IfcSIUnitName.CANDELA, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.PRESSUREUNIT, IfcSIUnitName.PASCAL, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.ELECTRICCURRENTUNIT, IfcSIUnitName.AMPERE, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.ELECTRICVOLTAGEUNIT, IfcSIUnitName.VOLT, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.FREQUENCYUNIT, IfcSIUnitName.HERTZ, null);
+			UnitsInContext = ua;
 
-        public IEnumerable<Xbim.Ifc4.Interfaces.IIfcSpatialStructureElement> SpatialStructuralElements
-        {
-            get
-            {
-                IEnumerable<IfcRelAggregates> aggregate = IsDecomposedBy.OfType<IfcRelAggregates>();
-                return aggregate.SelectMany(rel => rel.RelatedObjects.OfType<IfcSpatialStructureElement>());
-            }
-        }
+			//Create the Mandatory Model View
+			if (ModelContext == null)
+			{
+				var origin = model.Instances.New<IfcCartesianPoint>(p => p.SetXYZ(0, 0, 0));
+				var axis3D = model.Instances.New<IfcAxis2Placement3D>(a => a.Location = origin);
+				var gc = model.Instances.New<IfcGeometricRepresentationContext>(c =>
+				{
+					c.
+						ContextType
+						=
+						"Model";
+					c.
+						ContextIdentifier
+						=
+						"Building Model";
+					c.
+						CoordinateSpaceDimension
+						= 3;
+					c.Precision
+						=
+						0.00001;
+					c.
+						WorldCoordinateSystem
+						= axis3D;
+				}
+					);
+				RepresentationContexts.Add(gc);
 
-        /// <summary>
-        /// Makes a name out of the fields of this project
-        /// </summary>
-        /// <returns></returns>
-        public string BuildName()
-        {
-            List<string> tokens = new List<string>();
-            if (!string.IsNullOrWhiteSpace(Name)) tokens.Add(Name);
-            else if (!string.IsNullOrWhiteSpace(LongName)) tokens.Add(LongName);
-            else if (!string.IsNullOrWhiteSpace(Description)) tokens.Add(Description);
-            if (!string.IsNullOrWhiteSpace(Phase)) tokens.Add(Phase);
-            return string.Join(", ", tokens);
-        }
+				var origin2D = model.Instances.New<IfcCartesianPoint>(p => p.SetXY(0, 0));
+				var axis2D = model.Instances.New<IfcAxis2Placement2D>(a => a.Location = origin2D);
+				var pc = model.Instances.New<IfcGeometricRepresentationContext>(c =>
+				{
+					c.
+						ContextType
+						=
+						"Plan";
+					c.
+						ContextIdentifier
+						=
+						"Building Plan View";
+					c.
+						CoordinateSpaceDimension
+						= 2;
+					c.Precision
+						=
+						0.00001;
+					c.
+						WorldCoordinateSystem
+						= axis2D;
+				}
+					);
+				RepresentationContexts.Add(pc);
+
+			}
+		}
+
+		/// <summary>
+		/// Returns all buildings at the highest level of spatial structural decomposition (i.e. root buildings)
+		/// </summary>
+		public IEnumerable<Xbim.Ifc4.Interfaces.IIfcBuilding> Buildings
+		{
+			get
+			{
+				IEnumerable<IfcRelAggregates> aggregate = IsDecomposedBy.OfType<IfcRelAggregates>();
+				foreach (IfcRelAggregates rel in aggregate)
+				{
+					foreach (IfcObjectDefinition definition in rel.RelatedObjects)
+					{
+						var site = definition as IfcSite;
+						if (site != null)
+							foreach (var building in site.Buildings)
+								yield return building;
+						if (definition is IfcBuilding)
+							yield return (definition as IfcBuilding);
+					}
+				}
+			}
+		}
+
+		public IEnumerable<Xbim.Ifc4.Interfaces.IIfcSpatialStructureElement> SpatialStructuralElements
+		{
+			get
+			{
+				IEnumerable<IfcRelAggregates> aggregate = IsDecomposedBy.OfType<IfcRelAggregates>();
+				return aggregate.SelectMany(rel => rel.RelatedObjects.OfType<IfcSpatialStructureElement>());
+			}
+		}
+
+		/// <summary>
+		/// Makes a name out of the fields of this project
+		/// </summary>
+		/// <returns></returns>
+		public string BuildName()
+		{
+			List<string> tokens = new List<string>();
+			if (!string.IsNullOrWhiteSpace(Name)) tokens.Add(Name);
+			else if (!string.IsNullOrWhiteSpace(LongName)) tokens.Add(LongName);
+			else if (!string.IsNullOrWhiteSpace(Description)) tokens.Add(Description);
+			if (!string.IsNullOrWhiteSpace(Phase)) tokens.Add(Phase);
+			return string.Join(", ", tokens);
+		}
 
 
-        public IfcNamedUnit AreaUnit
-        {
-            get
-            {
-                return UnitsInContext.AreaUnit;                 
-            }
-            
-        }
+		public IfcNamedUnit AreaUnit
+		{
+			get
+			{
+				return UnitsInContext.AreaUnit;
+			}
 
-        public void SetOrChangeSiUnit(IfcUnitEnum unitType, IfcSIUnitName siUnitName,
-                                             IfcSIPrefix? siUnitPrefix)
-        {
-            if (UnitsInContext == null)
-            {
-                UnitsInContext = Model.Instances.New<IfcUnitAssignment>();
-            }
-            IfcUnitAssignment unitsAssignment = UnitsInContext;
-            unitsAssignment.SetOrChangeSiUnit(unitType, siUnitName, siUnitPrefix);
-        }
+		}
 
-        public void SetOrChangeConversionUnit(IfcUnitEnum unitType, ConversionBasedUnit conversionUnit)
-        {
-           
-            if (UnitsInContext == null)
-                UnitsInContext = Model.Instances.New<IfcUnitAssignment>();
-            IfcUnitAssignment unitsAssignment = UnitsInContext;
-            unitsAssignment.SetOrChangeConversionUnit(unitType, conversionUnit);
-        }
+		public void SetOrChangeSiUnit(IfcUnitEnum unitType, IfcSIUnitName siUnitName,
+											 IfcSIPrefix? siUnitPrefix)
+		{
+			if (UnitsInContext == null)
+			{
+				UnitsInContext = Model.Instances.New<IfcUnitAssignment>();
+			}
+			IfcUnitAssignment unitsAssignment = UnitsInContext;
+			unitsAssignment.SetOrChangeSiUnit(unitType, siUnitName, siUnitPrefix);
+		}
 
+		public void SetOrChangeConversionUnit(IfcUnitEnum unitType, ConversionBasedUnit conversionUnit)
+		{
 
-      
-
-        public IfcGeometricRepresentationContext PlanContext
-        {
-            get
-            {
-                return RepresentationContexts.FirstOrDefault < IfcGeometricRepresentationContext>(r => r.ContextType == "Plan");
-            }
-            
-        }
+			if (UnitsInContext == null)
+				UnitsInContext = Model.Instances.New<IfcUnitAssignment>();
+			IfcUnitAssignment unitsAssignment = UnitsInContext;
+			unitsAssignment.SetOrChangeConversionUnit(unitType, conversionUnit);
+		}
 
 
-        #region Decomposition methods
 
-        /// <summary>
-        ///   Adds Site to the IsDecomposedBy Collection.
-        /// </summary>
-        public  void AddSite(IfcSite site)
-        {
-            var decomposition = IsDecomposedBy.FirstOrDefault();
-            if (decomposition==null) //none defined create the relationship
-            {
-                var relSub = Model.Instances.New<IfcRelAggregates>();
-                relSub.RelatingObject = this;
-                relSub.RelatedObjects.Add(site);
-            }
-            else
-                decomposition.RelatedObjects.Add(site);
-        }
 
-        public IEnumerable<Xbim.Ifc4.Interfaces.IIfcSite> Sites
-        {
-            get
-            {
-                var aggregate = IsDecomposedBy.OfType<IfcRelAggregates>();
-                return from rel in aggregate from definition in Enumerable.OfType<IfcSite>(rel.RelatedObjects) select definition;
-            }
-        }
+		public IfcGeometricRepresentationContext PlanContext
+		{
+			get
+			{
+				return RepresentationContexts.FirstOrDefault<IfcGeometricRepresentationContext>(r => r.ContextType == "Plan");
+			}
 
-        /// <summary>
-        ///   Adds Building to the IsDecomposedBy Collection.
-        /// </summary>
-        public  void AddBuilding( IfcBuilding building)
-        {
-            var decomposition = IsDecomposedBy.FirstOrDefault();
-            if (decomposition==null) //none defined create the relationship
-            {
-                var relSub = Model.Instances.New<IfcRelAggregates>();
-                relSub.RelatingObject = this;
-                relSub.RelatedObjects.Add(building);
-            }
-            else
-                decomposition.RelatedObjects.Add(building);
-        }
+		}
 
-        #endregion
-   
 
-    }
+		#region Decomposition methods
 
+		/// <summary>
+		///   Adds Site to the IsDecomposedBy Collection.
+		/// </summary>
+		public void AddSite(IfcSite site)
+		{
+			var decomposition = IsDecomposedBy.FirstOrDefault();
+			if (decomposition == null) //none defined create the relationship
+			{
+				var relSub = Model.Instances.New<IfcRelAggregates>();
+				relSub.RelatingObject = this;
+				relSub.RelatedObjects.Add(site);
+			}
+			else
+				decomposition.RelatedObjects.Add(site);
+		}
+
+		public IEnumerable<Xbim.Ifc4.Interfaces.IIfcSite> Sites
+		{
+			get
+			{
+				var aggregate = IsDecomposedBy.OfType<IfcRelAggregates>();
+				return from rel in aggregate from definition in Enumerable.OfType<IfcSite>(rel.RelatedObjects) select definition;
+			}
+		}
+
+		/// <summary>
+		///   Adds Building to the IsDecomposedBy Collection.
+		/// </summary>
+		public void AddBuilding(IfcBuilding building)
+		{
+			var decomposition = IsDecomposedBy.FirstOrDefault();
+			if (decomposition == null) //none defined create the relationship
+			{
+				var relSub = Model.Instances.New<IfcRelAggregates>();
+				relSub.RelatingObject = this;
+				relSub.RelatedObjects.Add(building);
+			}
+			else
+				decomposition.RelatedObjects.Add(building);
+		}
+
+		#endregion
+	}
 }

--- a/Xbim.Ifc2x3/MeasureResource/IfcSIUnitPartial.cs
+++ b/Xbim.Ifc2x3/MeasureResource/IfcSIUnitPartial.cs
@@ -186,7 +186,7 @@ namespace Xbim.Ifc2x3.MeasureResource
                             prefix = "m";
                             break;
 						case IfcSIPrefix.MICRO:
-							prefix = "µ";
+							prefix = "\u00B5";
 							break;
 						case IfcSIPrefix.NANO:
 							prefix = "n";

--- a/Xbim.Ifc4/Kernel/IfcProjectPartial.cs
+++ b/Xbim.Ifc4/Kernel/IfcProjectPartial.cs
@@ -9,218 +9,198 @@ using Xbim.Ifc4.RepresentationResource;
 
 namespace Xbim.Ifc4.Interfaces
 {
-    public partial interface @IIfcProject
-    {
-        
-        void Initialize(ProjectUnits units);
-        IEnumerable<IIfcSite> Sites { get; }
-        IEnumerable<IIfcBuilding> Buildings { get; }
-        IEnumerable<IIfcSpatialStructureElement> SpatialStructuralElements { get; }
-    }
+	public partial interface @IIfcProject
+	{
+
+		void Initialize(ProjectUnits units);
+		IEnumerable<IIfcSite> Sites { get; }
+		IEnumerable<IIfcBuilding> Buildings { get; }
+		IEnumerable<IIfcSpatialStructureElement> SpatialStructuralElements { get; }
+	}
 }
 
 namespace Xbim.Ifc4.Kernel
 {
-    public partial class IfcProject
-    {
-        public IfcGeometricRepresentationContext ModelContext
-        {
-            get
-            {
-                return
-                    RepresentationContexts.
-                        FirstOrDefault<IfcGeometricRepresentationContext>(r => r.ContextType == "Model");
-            }
+	public partial class IfcProject
+	{
+		public IfcGeometricRepresentationContext ModelContext
+		{
+			get
+			{
+				return
+					RepresentationContexts.
+						FirstOrDefault<IfcGeometricRepresentationContext>(r => r.ContextType == "Model");
+			}
 
-        }
+		}
 
-        /// <summary>
-        ///   Sets up the default units as SI
-        ///   Creates the GeometricRepresentationContext for a Model view, required by Ifc compliance
-        /// </summary>
-        public void Initialize(ProjectUnits units)
-        {
-            var model = Model;
-            if (units == ProjectUnits.SIUnitsUK)
-            {
-                var ua = model.Instances.New<IfcUnitAssignment>();
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.LENGTHUNIT;
-                    s.Name = IfcSIUnitName.METRE;
-                    s.Prefix = IfcSIPrefix.MILLI;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.AREAUNIT;
-                    s.Name = IfcSIUnitName.SQUARE_METRE;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.VOLUMEUNIT;
-                    s.Name = IfcSIUnitName.CUBIC_METRE;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.SOLIDANGLEUNIT;
-                    s.Name = IfcSIUnitName.STERADIAN;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.PLANEANGLEUNIT;
-                    s.Name = IfcSIUnitName.RADIAN;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.MASSUNIT;
-                    s.Name = IfcSIUnitName.GRAM;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.TIMEUNIT;
-                    s.Name = IfcSIUnitName.SECOND;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType =
-                        IfcUnitEnum.THERMODYNAMICTEMPERATUREUNIT;
-                    s.Name = IfcSIUnitName.DEGREE_CELSIUS;
-                }));
-                ua.Units.Add(model.Instances.New<IfcSIUnit>(s =>
-                {
-                    s.UnitType = IfcUnitEnum.LUMINOUSINTENSITYUNIT;
-                    s.Name = IfcSIUnitName.LUMEN;
-                }));
-                UnitsInContext = ua;
-            }
-            //Create the Mandatory Model View
-            if (ModelContext == null)
-            {
-                var origin = model.Instances.New<IfcCartesianPoint>(p => p.SetXYZ(0, 0, 0));
-                var axis3D = model.Instances.New<IfcAxis2Placement3D>(a => a.Location = origin);
-                var gc = model.Instances.New<IfcGeometricRepresentationContext>(c =>
-                {
-                    c.
-                        ContextType
-                        =
-                        "Model";
-                    c.
-                        ContextIdentifier
-                        =
-                        "Building Model";
-                    c.
-                        CoordinateSpaceDimension
-                        = 3;
-                    c.Precision
-                        =
-                        0.00001;
-                    c.
-                        WorldCoordinateSystem
-                        = axis3D;
-                }
-                    );
-                RepresentationContexts.Add(gc);
+		/// <summary>
+		///   Sets up the default units as SI
+		///   Creates the GeometricRepresentationContext for a Model view, required by Ifc compliance
+		/// </summary>
+		public void Initialize(ProjectUnits units)
+		{
+			var model = Model;
+			var ua = model.Instances.New<IfcUnitAssignment>();
 
-                var origin2D = model.Instances.New<IfcCartesianPoint>(p => p.SetXY(0, 0));
-                var axis2D = model.Instances.New<IfcAxis2Placement2D>(a => a.Location = origin2D);
-                var pc = model.Instances.New<IfcGeometricRepresentationContext>(c =>
-                {
-                    c.
-                        ContextType
-                        =
-                        "Plan";
-                    c.
-                        ContextIdentifier
-                        =
-                        "Building Plan View";
-                    c.
-                        CoordinateSpaceDimension
-                        = 2;
-                    c.Precision
-                        =
-                        0.00001;
-                    c.
-                        WorldCoordinateSystem
-                        = axis2D;
-                }
-                    );
-                RepresentationContexts.Add(pc);
+			if (units == ProjectUnits.SIUnitsUK)
+			{
+				ua.SetOrChangeSiUnit(IfcUnitEnum.LENGTHUNIT, IfcSIUnitName.METRE, IfcSIPrefix.MILLI);
+				ua.SetOrChangeSiUnit(IfcUnitEnum.AREAUNIT, IfcSIUnitName.SQUARE_METRE, null);
+				ua.SetOrChangeSiUnit(IfcUnitEnum.VOLUMEUNIT, IfcSIUnitName.CUBIC_METRE, null);
+				ua.SetOrChangeSiUnit(IfcUnitEnum.MASSUNIT, IfcSIUnitName.GRAM, IfcSIPrefix.KILO);
+			}
+			else if (units == ProjectUnits.ImperialUnits || units == ProjectUnits.USCustomaryUnits)
+			{
+				ua.SetOrChangeConversionUnit(IfcUnitEnum.LENGTHUNIT, ConversionBasedUnit.Foot);
+				ua.SetOrChangeConversionUnit(IfcUnitEnum.AREAUNIT, ConversionBasedUnit.SquareFoot);
+				ua.SetOrChangeConversionUnit(IfcUnitEnum.VOLUMEUNIT, ConversionBasedUnit.CubicFoot);
+				ua.SetOrChangeConversionUnit(IfcUnitEnum.MASSUNIT, ConversionBasedUnit.Pound);
+			}
 
-            }
-        }
+			ua.SetOrChangeSiUnit(IfcUnitEnum.SOLIDANGLEUNIT, IfcSIUnitName.STERADIAN, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.PLANEANGLEUNIT, IfcSIUnitName.RADIAN, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.TIMEUNIT, IfcSIUnitName.SECOND, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.THERMODYNAMICTEMPERATUREUNIT, IfcSIUnitName.KELVIN, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.THERMODYNAMICTEMPERATUREUNIT, IfcSIUnitName.DEGREE_CELSIUS, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.POWERUNIT, IfcSIUnitName.WATT, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.FORCEUNIT, IfcSIUnitName.NEWTON, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.ILLUMINANCEUNIT, IfcSIUnitName.LUX, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.LUMINOUSFLUXUNIT, IfcSIUnitName.LUMEN, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.LUMINOUSINTENSITYUNIT, IfcSIUnitName.CANDELA, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.PRESSUREUNIT, IfcSIUnitName.PASCAL, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.ELECTRICCURRENTUNIT, IfcSIUnitName.AMPERE, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.ELECTRICVOLTAGEUNIT, IfcSIUnitName.VOLT, null);
+			ua.SetOrChangeSiUnit(IfcUnitEnum.FREQUENCYUNIT, IfcSIUnitName.HERTZ, null);
+			UnitsInContext = ua;
 
-        #region Decomposition methods
+			//Create the Mandatory Model View
+			if (ModelContext == null)
+			{
+				var origin = model.Instances.New<IfcCartesianPoint>(p => p.SetXYZ(0, 0, 0));
+				var axis3D = model.Instances.New<IfcAxis2Placement3D>(a => a.Location = origin);
+				var gc = model.Instances.New<IfcGeometricRepresentationContext>(c =>
+				{
+					c.
+						ContextType
+						=
+						"Model";
+					c.
+						ContextIdentifier
+						=
+						"Building Model";
+					c.
+						CoordinateSpaceDimension
+						= 3;
+					c.Precision
+						=
+						0.00001;
+					c.
+						WorldCoordinateSystem
+						= axis3D;
+				}
+					);
+				RepresentationContexts.Add(gc);
 
-        /// <summary>
-        ///   Adds Site to the IsDecomposedBy Collection.
-        /// </summary>
-        public void AddSite(IfcSite site)
-        {
-            var decomposition = IsDecomposedBy.FirstOrDefault();
-            if (decomposition == null) //none defined create the relationship
-            {
-                var relSub = Model.Instances.New<IfcRelAggregates>();
-                relSub.RelatingObject = this;
-                relSub.RelatedObjects.Add(site);
-            }
-            else
-                decomposition.RelatedObjects.Add(site);
-        }
+				var origin2D = model.Instances.New<IfcCartesianPoint>(p => p.SetXY(0, 0));
+				var axis2D = model.Instances.New<IfcAxis2Placement2D>(a => a.Location = origin2D);
+				var pc = model.Instances.New<IfcGeometricRepresentationContext>(c =>
+				{
+					c.
+						ContextType
+						=
+						"Plan";
+					c.
+						ContextIdentifier
+						=
+						"Building Plan View";
+					c.
+						CoordinateSpaceDimension
+						= 2;
+					c.Precision
+						=
+						0.00001;
+					c.
+						WorldCoordinateSystem
+						= axis2D;
+				}
+					);
+				RepresentationContexts.Add(pc);
 
-        public IEnumerable<IIfcSite> Sites
-        {
-            get {
-                return IsDecomposedBy.SelectMany(rel => Enumerable.OfType<IfcSite>(rel.RelatedObjects));
-            }
-        }
+			}
+		}
 
-        /// <summary>
-        ///   Adds Building to the IsDecomposedBy Collection.
-        /// </summary>
-        public void AddBuilding(IfcBuilding building)
-        {
-            var decomposition = IsDecomposedBy.FirstOrDefault();
-            if (decomposition == null) //none defined create the relationship
-            {
-                var relSub = Model.Instances.New<IfcRelAggregates>();
-                relSub.RelatingObject = this;
-                relSub.RelatedObjects.Add(building);
-            }
-            else           
-                decomposition.RelatedObjects.Add(building);
-        }
+		#region Decomposition methods
 
-        /// <summary>
-        /// Returns all buildings at the highest level of spatial structural decomposition (i.e. root buildings)
-        /// </summary>
-        public IEnumerable<IIfcBuilding> Buildings
-        {
-            get
-            {               
-                foreach (var rel in IsDecomposedBy)
-                {
-                    foreach (var definition in rel.RelatedObjects)
-                    {
-                        var site = definition as IfcSite;
-                        if (site != null)
-                            foreach (var building in site.Buildings)
-                                yield return building;
-                        if (definition is IfcBuilding)
-                            yield return (definition as IfcBuilding);
-                    }
-                }
-            }
-        }
+		/// <summary>
+		///   Adds Site to the IsDecomposedBy Collection.
+		/// </summary>
+		public void AddSite(IfcSite site)
+		{
+			var decomposition = IsDecomposedBy.FirstOrDefault();
+			if (decomposition == null) //none defined create the relationship
+			{
+				var relSub = Model.Instances.New<IfcRelAggregates>();
+				relSub.RelatingObject = this;
+				relSub.RelatedObjects.Add(site);
+			}
+			else
+				decomposition.RelatedObjects.Add(site);
+		}
 
-        public IEnumerable<IIfcSpatialStructureElement> SpatialStructuralElements
-        {
-            get
-            {
-                return IsDecomposedBy.SelectMany(rel => rel.RelatedObjects.OfType<IfcSpatialStructureElement>());
-            }
-        }
-        #endregion
+		public IEnumerable<IIfcSite> Sites
+		{
+			get
+			{
+				return IsDecomposedBy.SelectMany(rel => Enumerable.OfType<IfcSite>(rel.RelatedObjects));
+			}
+		}
 
-    }
+		/// <summary>
+		///   Adds Building to the IsDecomposedBy Collection.
+		/// </summary>
+		public void AddBuilding(IfcBuilding building)
+		{
+			var decomposition = IsDecomposedBy.FirstOrDefault();
+			if (decomposition == null) //none defined create the relationship
+			{
+				var relSub = Model.Instances.New<IfcRelAggregates>();
+				relSub.RelatingObject = this;
+				relSub.RelatedObjects.Add(building);
+			}
+			else
+				decomposition.RelatedObjects.Add(building);
+		}
 
+		/// <summary>
+		/// Returns all buildings at the highest level of spatial structural decomposition (i.e. root buildings)
+		/// </summary>
+		public IEnumerable<IIfcBuilding> Buildings
+		{
+			get
+			{
+				foreach (var rel in IsDecomposedBy)
+				{
+					foreach (var definition in rel.RelatedObjects)
+					{
+						var site = definition as IfcSite;
+						if (site != null)
+							foreach (var building in site.Buildings)
+								yield return building;
+						if (definition is IfcBuilding)
+							yield return (definition as IfcBuilding);
+					}
+				}
+			}
+		}
+
+		public IEnumerable<IIfcSpatialStructureElement> SpatialStructuralElements
+		{
+			get
+			{
+				return IsDecomposedBy.SelectMany(rel => rel.RelatedObjects.OfType<IfcSpatialStructureElement>());
+			}
+		}
+		#endregion
+	}
 }

--- a/Xbim.Ifc4/MeasureResource/IfcSIUnitPartial.cs
+++ b/Xbim.Ifc4/MeasureResource/IfcSIUnitPartial.cs
@@ -214,7 +214,7 @@ namespace Xbim.Ifc4.MeasureResource
                             prefix = "m";
                             break;
 						case IfcSIPrefix.MICRO:
-							prefix = "µ";
+							prefix = "\u00B5";
 							break;
 						case IfcSIPrefix.NANO:
 							prefix = "n";


### PR DESCRIPTION
[ADDED] Add some common SI Unit used in all common IfcProject file.
[CHANGED] Slightly change the  "ProjectUnits" to add imperial in the enum and use SetOrChangeSiUnit to simplify the reading in IfcProject initialization process
[CHANGED] Replace "µ" by its unicode value
