### PR TITLE
IfcCalendarDate.ToString and unrequired folder creation

### DIFF
--- a/Xbim.Ifc2x3/DateTimeResource/IfcCalendarDate.cs
+++ b/Xbim.Ifc2x3/DateTimeResource/IfcCalendarDate.cs
@@ -149,6 +149,10 @@ namespace Xbim.Ifc2x3.DateTimeResource
 		#region Custom code (will survive code regeneration)
 		//## Custom code
 		//##
+		public override string ToString ()
+		{
+			return string.Format ("{0}-{1}-{2}", YearComponent, MonthComponent, DayComponent);
+		}
 		#endregion
 	}
 }


### PR DESCRIPTION
1. Fixed: even log4net.GlobalContext.Properties["LogName"] was set,
Log4NetProvider.Initialise created empty folder for default log file
location

2. Implement IfcCalendarDate.ToString to provide date string.
The call is used in XbimExchange\Xbim.COBie\Data\COBieDataAttributeBuilder.cs
and populated COBies Attribure sheet with string "Xbim.Ifc2x3.DateTimeResource.IfcCalendarDate"
