### PR TITLE
Fix for ifcxml if RelatedObjects is Empty Element

### DIFF
--- a/Xbim.IO.Tests/TestFiles/QuantityTest.ifcxml
+++ b/Xbim.IO.Tests/TestFiles/QuantityTest.ifcxml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ifcXML xmlns:ifc="http://www.buildingsmart-tech.org/ifcXML/IFC4/final" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="ifcXML4" xsi:schemaLocation="http://www.buildingsmart-tech.org/ifcXML/IFC4/final http://www.buildingsmart-tech.org/ifcXML/IFC4/final/ifcXML4.xsd" xmlns="http://www.buildingsmart-tech.org/ifcXML/IFC4/final">
+  <header>
+    <name>QuantityTest</name>
+    <author>mk</author>
+  </header>
+  <IfcProject id="p1" GlobalId="3W_wCy4R58hgkAO0WsiUkm" Name="P"/>
+  <!--Test for site -->
+  <IfcSite id="s1" GlobalId="1lOEDpLKz62xrR7$RUqRl$" Name="S"/>
+  <IfcRelAggregates>
+    <RelatingObject xsi:type="IfcProject" ref="p1" />
+    <RelatedObjects>
+      <IfcSite xsi:nil="true" ref="s1" />
+    </RelatedObjects>
+  </IfcRelAggregates>
+  <!-- Test for Quantities-->
+  <IfcQuantityArea id="x1" Name="TestArea" AreaValue="2" />
+  <IfcElementQuantity id ="x2" Name ="TestQuantities">
+    <Quantities>
+      <IfcQuantityArea ref="x1"/>
+    </Quantities>
+  </IfcElementQuantity>
+  <IfcRelDefinesByProperties id="x3">
+    <RelatedObjects xsi:type="IfcSite" ref="s1"/>
+    <RelatingPropertyDefinition>
+      <IfcElementQuantity xsi:nil="true" ref="x2"/>
+    </RelatingPropertyDefinition>
+  </IfcRelDefinesByProperties>
+</ifcXML>

--- a/Xbim.IO.Tests/TestFiles/QuantityTest.ifcxml
+++ b/Xbim.IO.Tests/TestFiles/QuantityTest.ifcxml
@@ -5,8 +5,6 @@
     <author>mk</author>
   </header>
   <IfcProject id="p1" GlobalId="3W_wCy4R58hgkAO0WsiUkm" Name="P"/>
-  <!--Test for site -->
-  <IfcSite id="s1" GlobalId="1lOEDpLKz62xrR7$RUqRl$" Name="S"/>
   <IfcRelAggregates>
     <RelatingObject xsi:type="IfcProject" ref="p1" />
     <RelatedObjects>
@@ -21,7 +19,15 @@
     </Quantities>
   </IfcElementQuantity>
   <IfcRelDefinesByProperties id="x3">
-    <RelatedObjects xsi:type="IfcSite" ref="s1"/>
+    <!-- Site def. in RelatedObjects-->
+    <RelatedObjects xsi:type="IfcSite" id="s1"
+    GlobalId="1lOEDpLKz62xrR7$RUqRl$"
+    Name="Testsite">
+      <SiteAddress id="i26" xsi:type="IfcPostalAddress"
+        Purpose="site"
+        Town="Newcastle upon Tyne"
+        Region="Tyne and Wear" PostalCode="NE6 2SY" Country="United Kingdom" />
+    </RelatedObjects>
     <RelatingPropertyDefinition>
       <IfcElementQuantity xsi:nil="true" ref="x2"/>
     </RelatingPropertyDefinition>

--- a/Xbim.IO.Tests/Xbim.IO.Tests.csproj
+++ b/Xbim.IO.Tests/Xbim.IO.Tests.csproj
@@ -213,6 +213,10 @@
     <None Include="TestFiles\OneWall.xBIM">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="TestFiles\QuantityTest.ifcxml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
+    </None>
     <None Include="TestFiles\Roof-01_BCAD.ifc">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Xbim.IO.Tests/XmlTests4.cs
+++ b/Xbim.IO.Tests/XmlTests4.cs
@@ -45,7 +45,7 @@ namespace Xbim.MemoryModel.Tests
         {
             var path = @"QuantityTest.ifcxml";
             var store = Xbim.Ifc.IfcStore.Open(path);
-            var site = store.Instances.FirstOrDefault<IIfcSite>(r => r.Name == "S");
+            var site = store.Instances.FirstOrDefault<IIfcSite>(r => r.Name == "Testsite");
             var rel = site.IsDefinedBy
                     .Where(r => r.RelatingPropertyDefinition is IIfcElementQuantity)
                     .FirstOrDefault();

--- a/Xbim.IO.Tests/XmlTests4.cs
+++ b/Xbim.IO.Tests/XmlTests4.cs
@@ -40,7 +40,17 @@ namespace Xbim.MemoryModel.Tests
                 model.LoadXml(path);
             }
         }
-
+        [TestMethod]
+        public void CheckQuantity()
+        {
+            var path = @"QuantityTest.ifcxml";
+            var store = Xbim.Ifc.IfcStore.Open(path);
+            var site = store.Instances.FirstOrDefault<IIfcSite>(r => r.Name == "S");
+            var rel = site.IsDefinedBy
+                    .Where(r => r.RelatingPropertyDefinition is IIfcElementQuantity)
+                    .FirstOrDefault();
+            Assert.IsNotNull(rel);
+        }
         [TestMethod]
         public void Ifc4HeaderSerialization()
         {

--- a/Xbim.IO/Xml/XbimXmlReader4.cs
+++ b/Xbim.IO/Xml/XbimXmlReader4.cs
@@ -396,7 +396,7 @@ namespace Xbim.IO.Xml
 
             if (typeof(IPersistEntity).IsAssignableFrom(type) || 
                 (typeof(IEnumerable).IsAssignableFrom(type) && property.EntityAttribute.MaxCardinality == 1) ||
-                (typeof(IEnumerable).IsAssignableFrom(type) && input.IsEmptyElement && input.GetAttribute("type",_xsi)!=null)
+                (typeof(IEnumerable).IsAssignableFrom(type) && input.GetAttribute("type",_xsi)!=null)
                 )
             {
                 var value = ReadEntity(input, type);

--- a/Xbim.IO/Xml/XbimXmlReader4.cs
+++ b/Xbim.IO/Xml/XbimXmlReader4.cs
@@ -395,7 +395,9 @@ namespace Xbim.IO.Xml
             }
 
             if (typeof(IPersistEntity).IsAssignableFrom(type) || 
-                (typeof(IEnumerable).IsAssignableFrom(type) && property.EntityAttribute.MaxCardinality == 1))
+                (typeof(IEnumerable).IsAssignableFrom(type) && property.EntityAttribute.MaxCardinality == 1) ||
+                (typeof(IEnumerable).IsAssignableFrom(type) && input.IsEmptyElement && input.GetAttribute("type",_xsi)!=null)
+                )
             {
                 var value = ReadEntity(input, type);
                 var pVal = new PropertyValue();


### PR DESCRIPTION
fix for #187 

fix for parsing ifcxml, if model is ifc4 (not add1 or add2), which contains RelatedObjects as an empty element with type definition. 