### PR TITLE
Make _geometryContextId and _instanceContextId non static

### DIFF
--- a/Xbim.IO/Esent/EsentGeometryInitialiser.cs
+++ b/Xbim.IO/Esent/EsentGeometryInitialiser.cs
@@ -16,8 +16,8 @@ namespace Xbim.IO.Esent
         private EsentLazyDBTransaction _shapeInstanceTransaction;
         private int _geometryCount;
         private int _instanceCount;
-        private static IntPtr _geometryContextId;
-        private static IntPtr _instanceContextId;
+        private IntPtr _geometryContextId;
+        private IntPtr _instanceContextId;
 private  bool _disposed;
         public EsentGeometryInitialiser(EsentGeometryStore esentGeometryStore, EsentShapeGeometryCursor shapeGeometryCursor, EsentShapeInstanceCursor shapeInstanceCursor)
         {


### PR DESCRIPTION
Having these static prevented running multiple EsentGeometryStore.BeginInit() / Xbim3DModelContext.CreateContext(...) on different models at the same time.
The context variables would be overwritten once the 2nd instance of EsentGeometryInitialiser was created, causing a "multiple threads are using the same session" error from the esent/jet database native code.
Updated this to not be static and tested, and everything seems to work perfectly.