### PR TITLE
Fixing issue #92 of xBimTeam/XbimGeometry

### DIFF
--- a/Xbim.Ifc4/IXbimGeometryEngine.cs
+++ b/Xbim.Ifc4/IXbimGeometryEngine.cs
@@ -40,8 +40,8 @@ namespace Xbim.Ifc4.Interfaces
         IXbimSolid CreateSolid(IIfcBoundingBox ifcSolid);
         IXbimSolid CreateSolid(IIfcSurfaceCurveSweptAreaSolid ifcSolid);
 
-        IXbimSolid CreateSolid(IIfcBooleanClippingResult ifcSolid);
-        IXbimSolid CreateSolid(IIfcBooleanOperand ifcSolid);
+        IXbimSolidSet CreateSolidSet(IIfcBooleanClippingResult ifcSolid);
+        IXbimSolidSet CreateSolidSet(IIfcBooleanOperand ifcSolid);
         IXbimSolid CreateSolid(IIfcHalfSpaceSolid ifcSolid);
         IXbimSolid CreateSolid(IIfcPolygonalBoundedHalfSpace ifcSolid);
         IXbimSolid CreateSolid(IIfcBoxedHalfSpace ifcSolid);
@@ -52,7 +52,7 @@ namespace Xbim.Ifc4.Interfaces
         IXbimSolidSet CreateSolidSet(IIfcClosedShell ifcSolid);
 
         IXbimSolid CreateSolid(IIfcCsgPrimitive3D ifcSolid);
-        IXbimSolid CreateSolid(IIfcCsgSolid ifcSolid);
+        IXbimSolidSet CreateSolidSet(IIfcCsgSolid ifcSolid);
         IXbimSolid CreateSolid(IIfcSphere ifcSolid);
         IXbimSolid CreateSolid(IIfcBlock ifcSolid);
         IXbimSolid CreateSolid(IIfcRightCircularCylinder ifcSolid);


### PR DESCRIPTION
Fixes the CSG operation problem of more complex CSG trees with multiple solid outcomes (initially labeled as repeated elements).
Reference https://github.com/xBimTeam/XbimGeometry/issues/92