### PR TITLE
[FIXED] Fix missing FileName filling when Assigning model

### DIFF
--- a/Xbim.Ifc/IfcStore.cs
+++ b/Xbim.Ifc/IfcStore.cs
@@ -135,7 +135,7 @@ namespace Xbim.Ifc
             Model.EntityNew += Model_EntityNew;
             Model.EntityDeleted += Model_EntityDeleted;
             Model.EntityModified += Model_EntityModified;
-            FileName = null;
+            FileName = Model.Header.FileName.Name;
             SetupEditing(editorDetails);
 
             LoadReferenceModels();


### PR DESCRIPTION
The fileName value is not pached during the model assignment on 5.0.X.
