### PR TITLE
Fix incorrect format of doubles in created IFC files

### DIFF
--- a/Tests/Part21FormatterTests.cs
+++ b/Tests/Part21FormatterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,28 +12,122 @@ namespace Xbim.Essentials.Tests
     [TestClass]
     public class Part21FormatterTests
     {
+        public static string fmt = "R";
+        //public static string fmt = "G";
+        //public static string fmt = "G17";
+
         [TestMethod]
         public void FormatDoubleScientificNotation()
         {
             Part21Formatter formatter = new Part21Formatter();
-            string fmt_1 = "G";
             double arg = 0.0000053;
 
-            string result_1 = formatter.Format(fmt_1, arg, null);
+            string result = formatter.Format(fmt, arg, null);
             string expected = "5.3E-06";
-            Assert.AreEqual(expected, result_1, "Wrong conversion!");
+            Assert.AreEqual(expected, result, "Wrong conversion!");
+        }
+
+        [TestMethod]
+        public void FormatDoubleScientificNotationRoundTrip()
+        {
+            Part21Formatter formatter = new Part21Formatter();
+            double arg = 0.0000053;
+
+            string result = formatter.Format(fmt, arg, null);
+            var roundTripDbl = double.Parse(result, new CultureInfo("en-US", false));
+            Assert.AreEqual(arg, roundTripDbl, "Wrong conversion!");
         }
 
         [TestMethod]
         public void FormatDouble()
         {
             Part21Formatter formatter = new Part21Formatter();
-            string fmt_1 = "G";
-            double arg = -12345678.5321;
+            double arg = -12345678.5323;
 
-            string result_1 = formatter.Format(fmt_1, arg, null);
-            string expected = "-12345678.5321";
-            Assert.AreEqual(expected, result_1, "Wrong conversion!");
+            string result = formatter.Format(fmt, arg, null);
+            string expected = "-12345678.5323";
+            Assert.AreEqual(expected, result, "Wrong conversion!");
+        }
+
+        [TestMethod]
+        public void FormatDoubleRoundTrip()
+        {
+            Part21Formatter formatter = new Part21Formatter();
+            double arg = -12345678.5323;
+
+            string result = formatter.Format(fmt, arg, null);
+            var roundTripDbl = double.Parse(result, new CultureInfo("en-US", false));
+            Assert.AreEqual(arg, roundTripDbl, "Wrong conversion!");
+        }
+
+        [TestMethod]
+        public void FormatDoubleLargeDecimal()
+        {
+            Part21Formatter formatter = new Part21Formatter();
+            // Number from G specifier example
+            // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings?view=netframework-4.8#the-general-g-format-specifier
+            double arg = 0.84551240822557006;
+
+            string result = formatter.Format(fmt, arg, null);
+            string expected = "0.84551240822557006";
+            Assert.AreEqual(expected, result, "Wrong conversion!");
+        }
+
+        [TestMethod]
+        public void FormatDoubleLargeDecimalRoundTrip()
+        {
+            Part21Formatter formatter = new Part21Formatter();
+            // Number from G specifier example
+            // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings?view=netframework-4.8#the-general-g-format-specifier
+            double arg = 0.84551240822557006;
+
+            string result = formatter.Format(fmt, arg, null);
+            var roundTripDbl = double.Parse(result, new CultureInfo("en-US", false));
+            Assert.AreEqual(arg, roundTripDbl, "Wrong conversion!");
+        }
+
+        [TestMethod]
+        public void FormatDoubleWithoutDecimal()
+        {
+            Part21Formatter formatter = new Part21Formatter();
+            double arg = -12345678;
+
+            string result = formatter.Format(fmt, arg, null);
+            string expected = "-12345678.";
+            Assert.AreEqual(expected, result, "Wrong conversion!");
+        }
+
+        [TestMethod]
+        public void FormatDoubleWithoutDecimalRoundTrip()
+        {
+            Part21Formatter formatter = new Part21Formatter();
+            double arg = -12345678;
+
+            string result = formatter.Format(fmt, arg, null);
+            var roundTripDbl = double.Parse(result, new CultureInfo("en-US", false));
+            Assert.AreEqual(arg, roundTripDbl, "Wrong conversion!");
+        }
+
+        [TestMethod]
+        public void FormatDoubleWithoutDecimalLarge()
+        {
+            Part21Formatter formatter = new Part21Formatter();
+            double arg = -1234567812345678;
+
+            string result = formatter.Format(fmt, arg, null);
+            string expected = "-1234567812345678.";
+            Assert.AreEqual(expected, result, "Wrong conversion!");
+        }
+
+        [TestMethod]
+        public void FormatDoubleWithoutDecimalLargeRoundTrip()
+        {
+            Part21Formatter formatter = new Part21Formatter();
+            double arg = -1234567812345678;
+
+            string result = formatter.Format(fmt, arg, null);
+            var roundTripDbl = double.Parse(result, new CultureInfo("en-US", false));
+            Assert.AreEqual(arg, roundTripDbl, "Wrong conversion!");
         }
     }
 }

--- a/Tests/Part21FormatterTests.cs
+++ b/Tests/Part21FormatterTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xbim.IO.Step21;
+
+namespace Xbim.Essentials.Tests
+{
+    [TestClass]
+    public class Part21FormatterTests
+    {
+        [TestMethod]
+        public void FormatDoubleScientificNotation()
+        {
+            Part21Formatter formatter = new Part21Formatter();
+            string fmt_1 = "G";
+            double arg = 0.0000053;
+
+            string result_1 = formatter.Format(fmt_1, arg, null);
+            string expected = "5.3E-06";
+            Assert.AreEqual(expected, result_1, "Wrong conversion!");
+        }
+
+        [TestMethod]
+        public void FormatDouble()
+        {
+            Part21Formatter formatter = new Part21Formatter();
+            string fmt_1 = "G";
+            double arg = -12345678.5321;
+
+            string result_1 = formatter.Format(fmt_1, arg, null);
+            string expected = "-12345678.5321";
+            Assert.AreEqual(expected, result_1, "Wrong conversion!");
+        }
+    }
+}

--- a/Xbim.Common/Step21/Part21Formatter.cs
+++ b/Xbim.Common/Step21/Part21Formatter.cs
@@ -32,13 +32,13 @@ namespace Xbim.IO.Step21
         {
             // Convert argument to a string           
 
-            if (!string.IsNullOrEmpty(fmt) && fmt.ToUpper() == "G" && arg is double)
+            if (!string.IsNullOrEmpty(fmt) && fmt.ToUpper() == "R" && arg is double)
             {
                 var dArg = (double)arg;
-                return dArg.ToString("G", StepText.DoubleCulture);
+                var result = dArg.ToString("R", StepText.DoubleCulture);
 
                 // if compiler flag, only then do the following 3 lines
-          
+
                 //var rDoubleStr = dArg.ToString("R", StepText.DoubleCulture);
                 //var fixedDbl = double.Parse(rDoubleStr, StepText.DoubleCulture);
                 //var result = fixedDbl.ToString("R", StepText.DoubleCulture);
@@ -47,14 +47,14 @@ namespace Xbim.IO.Step21
                 // string result = decArg.ToString().ToUpper();
                 // string result = string.Format("{0:e22}", arg);
                 //string result = dArg.ToString("R", CultureInfo.CreateSpecificCulture("en-US"));
-                //if (result.Contains(".")) return result;
+                if (result.Contains(".")) return result;
 
-                //if (result.Contains("E"))
-                //    result = result.Replace("E", ".E");
-                //else
-                //    result += ".";
+                if (result.Contains("E"))
+                    result = result.Replace("E", ".E");
+                else
+                    result += ".";
 
-                //return result;
+                return result;
             }
             if (!string.IsNullOrEmpty(fmt) && fmt.ToUpper() == "T") //TimeStamp
             {

--- a/Xbim.Common/Step21/Part21Formatter.cs
+++ b/Xbim.Common/Step21/Part21Formatter.cs
@@ -21,7 +21,7 @@ namespace Xbim.IO.Step21
 {
     public class Part21Formatter : IFormatProvider, ICustomFormatter
     {
-        private static readonly CultureInfo _cInfo = new CultureInfo("en-US");
+        private static readonly CultureInfo _cInfo = new CultureInfo("en-US", false);
 
         public object GetFormat(Type formatType)
         {
@@ -32,28 +32,29 @@ namespace Xbim.IO.Step21
         {
             // Convert argument to a string           
 
-            if (!string.IsNullOrEmpty(fmt) && fmt.ToUpper() == "R" && arg is double)
+            if (!string.IsNullOrEmpty(fmt) && fmt.ToUpper() == "G" && arg is double)
             {
                 var dArg = (double)arg;
+                return dArg.ToString("G", StepText.DoubleCulture);
 
                 // if compiler flag, only then do the following 3 lines
           
-                var rDoubleStr = dArg.ToString("R", StepText.DoubleCulture);
-                var fixedDbl = double.Parse(rDoubleStr, StepText.DoubleCulture);
-                var result = fixedDbl.ToString("R", StepText.DoubleCulture);
+                //var rDoubleStr = dArg.ToString("R", StepText.DoubleCulture);
+                //var fixedDbl = double.Parse(rDoubleStr, StepText.DoubleCulture);
+                //var result = fixedDbl.ToString("R", StepText.DoubleCulture);
 
                 //decimal decArg = new Decimal(dArg);                                
                 // string result = decArg.ToString().ToUpper();
                 // string result = string.Format("{0:e22}", arg);
                 //string result = dArg.ToString("R", CultureInfo.CreateSpecificCulture("en-US"));
-                if (result.Contains(".")) return result;
+                //if (result.Contains(".")) return result;
 
-                if (result.Contains("E"))
-                    result = result.Replace("E", ".E");
-                else
-                    result += ".";
+                //if (result.Contains("E"))
+                //    result = result.Replace("E", ".E");
+                //else
+                //    result += ".";
 
-                return result;
+                //return result;
             }
             if (!string.IsNullOrEmpty(fmt) && fmt.ToUpper() == "T") //TimeStamp
             {

--- a/Xbim.Common/Step21/StepTextHelper.cs
+++ b/Xbim.Common/Step21/StepTextHelper.cs
@@ -6,7 +6,7 @@ namespace Xbim.IO.Step21
 {
     public static class StepText
     {
-        internal static readonly CultureInfo DoubleCulture = new CultureInfo("en-US");
+        internal static readonly CultureInfo DoubleCulture = new CultureInfo("en-US", false); // false - because we shouldn't use overriden settings
         public static double ToDouble(this string val)
         {
             switch (val)


### PR DESCRIPTION
[BUG]BIMx writes real numbers in files like this: 123,45.E-10 because of local user overrides. IFC viewers can't parse this, so we should get 123.45E-10 with dot instead of comma.
[ISSUE]"We recommend use "G" instead of the "R" format specifier, since in some cases "R" fails to successfully round-trip double-precision floating point values." - from here [https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings?view=netframework-4.8#the-general-g-format-specifier](url)
[CHANGED]Get rid of redundant . before E in real numbers with scientific notation for new IFC files.
[CHANGED]Format specifier changed to G.
[CHANGED]Constructor for CultureInfo object now set useUserOverride to false.
[ADDED]Test case for converting doubles to string.