### PR TITLE
Improvements to XbimTessellator

### DIFF
--- a/Xbim.Common/Geometry/IXbimGeometryObject.cs
+++ b/Xbim.Common/Geometry/IXbimGeometryObject.cs
@@ -30,8 +30,9 @@ namespace Xbim.Common.Geometry
         /// Gets or sets an arbitrary object value that can be used to store custom information about this element
         /// </summary>
         object Tag { get; set; }
-
-       
-       
+        /// <summary>
+        /// Returns the volume which is closed and valid, if there's an existing closed shell.
+        /// </summary>
+        double? Volume { get; }
     }
 }

--- a/Xbim.Common/Geometry/IXbimGeometryObjectSet.cs
+++ b/Xbim.Common/Geometry/IXbimGeometryObjectSet.cs
@@ -32,7 +32,10 @@ namespace Xbim.Common.Geometry
         /// Converts the object to a string in BRep format
         /// </summary>
         String ToBRep { get; }
-
+        /// <summary>
+        /// Returns the partial volume of the set which is closed and valid.
+        /// </summary>
+        double VolumeValid { get; }
     }
 
 }

--- a/Xbim.Common/Geometry/IXbimShapeGeometryData.cs
+++ b/Xbim.Common/Geometry/IXbimShapeGeometryData.cs
@@ -50,5 +50,10 @@
         /// LocalShapeDisplacement and should be added to placement of the shape in the product.
         /// </summary>
         IVector3D LocalShapeDisplacement { get; }
+
+        /// <summary>
+        /// Returns the volume which is closed and valid, if there's an existing closed shell.
+        /// </summary>
+        double? Volume { get; }
     }
 }

--- a/Xbim.Common/Geometry/IXbimShellSet.cs
+++ b/Xbim.Common/Geometry/IXbimShellSet.cs
@@ -20,5 +20,10 @@ namespace Xbim.Common.Geometry
         /// </summary>
         /// <param name="tolerance"></param>
         void Union(double tolerance);
+
+        /// <summary>
+        /// Returns the partial volume of the set which is closed and valid.
+        /// </summary>
+        double VolumeValid { get; }
     }
 }

--- a/Xbim.Common/Geometry/IXbimSolid.cs
+++ b/Xbim.Common/Geometry/IXbimSolid.cs
@@ -12,8 +12,7 @@ namespace Xbim.Common.Geometry
         IXbimShellSet Shells { get; }
         IXbimFaceSet Faces { get; }
         IXbimEdgeSet Edges { get; }
-        IXbimVertexSet Vertices { get; }
-        double Volume { get; }
+        IXbimVertexSet Vertices { get; }        
         double SurfaceArea { get; }
         bool IsPolyhedron { get; }
         IXbimSolidSet Cut(IXbimSolidSet toCut, double tolerance, ILogger logger=null);

--- a/Xbim.Common/Geometry/IXbimSolidSet.cs
+++ b/Xbim.Common/Geometry/IXbimSolidSet.cs
@@ -25,5 +25,9 @@ namespace Xbim.Common.Geometry
         /// Converts the object to a string in BRep format
         /// </summary>
         String ToBRep { get; }
+        /// <summary>
+        /// Returns the partial volume of the set which is closed and valid.
+        /// </summary>
+        double VolumeValid { get; }
     }
 }

--- a/Xbim.Common/Geometry/XbimRegionCollection.cs
+++ b/Xbim.Common/Geometry/XbimRegionCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -282,5 +283,10 @@ namespace Xbim.Common.Geometry
         }
 
         IVector3D IXbimShapeGeometryData.LocalShapeDisplacement => null;
+
+        ///<summary>
+        ///Returns the sum of bounding box volumes of this region collection.
+        ///</summary>
+        public double? Volume => this.Select(r => r.ToXbimRect3D().Volume).Sum();
     }
 }

--- a/Xbim.Common/Geometry/XbimShapeGeometry.cs
+++ b/Xbim.Common/Geometry/XbimShapeGeometry.cs
@@ -91,6 +91,10 @@ namespace Xbim.Common.Geometry
         /// </summary>
         byte[] _shapeData;
 
+        /// <summary>
+        /// The volume if available
+        /// </summary>
+        double? _volume;
 
 
         /// <summary>
@@ -331,6 +335,14 @@ namespace Xbim.Common.Geometry
         IVector3D IXbimShapeGeometryData.LocalShapeDisplacement => LocalShapeDisplacement;
         public XbimVector3D? LocalShapeDisplacement { get; set; }
 
-
+        public double? Volume
+        {
+            get {
+                return _volume;
+            }
+            set {
+                _volume = value;
+            }
+        }
     }
 }

--- a/Xbim.Tessellator/MeshUtils.cs
+++ b/Xbim.Tessellator/MeshUtils.cs
@@ -36,6 +36,10 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+using Xbim.Common.Geometry;
+using Xbim.Common.XbimExtensions;
+using Xbim.Ifc4.MeasureResource;
+
 namespace Xbim.Tessellator
 {
     public struct Vec3EqualityComparer : IEqualityComparer<Vec3>
@@ -106,7 +110,19 @@ namespace Xbim.Tessellator
             // ReSharper restore CompareOfFloatsByEqualityOperator
         }
 
-       
+        public Vec3(XbimTriplet<IfcParameterValue> triple)
+        {
+            X = triple.A;
+            Y = triple.B;
+            Z = triple.C;
+        }
+
+        public Vec3(XbimPoint3D p)
+        {
+            X = p.X;
+            Y = p.Y;
+            Z = p.Z;
+        }
 
         public Vec3(double x, double y, double z)
         {
@@ -151,6 +167,7 @@ namespace Xbim.Tessellator
         {
             get { return Length2 > 0; }
         }
+
         public static double Angle(ref Vec3 v1, ref Vec3 v2)
         {
             double cosinus;
@@ -163,6 +180,7 @@ namespace Xbim.Tessellator
             if (cosinus < 0.0) return Math.PI - Math.Asin(sinus);
             return Math.Asin(sinus);
         }
+
         public static void Neg(ref Vec3 v)
         {
             v.X = -v.X;

--- a/Xbim.Tessellator/XbimTessellator.cs
+++ b/Xbim.Tessellator/XbimTessellator.cs
@@ -7,26 +7,28 @@ using Xbim.Common.Geometry;
 using Xbim.Ifc4.Interfaces;
 using Xbim.Common.XbimExtensions;
 using Xbim.Ifc4.MeasureResource;
-using Xbim.Common.Collections;
+using Microsoft.Extensions.Logging;
+using System.Text;
 
 namespace Xbim.Tessellator
 {
-
     public class XbimTessellator
     {
         private readonly IModel _model;
         private readonly XbimGeometryType _geometryType;
-        public XbimTessellator(IModel model, XbimGeometryType geometryType)
+        private readonly ILogger _logger;        
+
+        public XbimTessellator(IModel model, XbimGeometryType geometryType, ILogger logger = null)
         {
             _model = model;
             _geometryType = geometryType;
+            _logger = logger;
         }
 
-        public IXbimShapeGeometryData Mesh(IXbimGeometryObject geomObject)
-        {
-            return new XbimShapeGeometry();
-
-        }
+        /// <summary>
+        /// Issue reporting mask. Default reports only open bodies.
+        /// </summary>
+        public XbimTriangulationStatus ReportMask { get; set; } = XbimTriangulationStatus.IsOpenBody;
 
         /// <summary>
         /// Returns true if the object can be meshed by the tesselator, if it cannot create an IXbimGeometryObject
@@ -50,7 +52,7 @@ namespace Xbim.Tessellator
             var sbm = shape as IIfcShellBasedSurfaceModel;
             if (sbm != null) return Mesh(sbm);
             var cfs = shape as IIfcConnectedFaceSet;
-            if (cfs != null) return Mesh(cfs);
+            if (cfs != null) return Mesh(cfs, false);
             var fbr = shape as IIfcFacetedBrep;
             if (fbr != null) return Mesh(fbr);
             var tfs = shape as IIfcTriangulatedFaceSet;
@@ -60,16 +62,13 @@ namespace Xbim.Tessellator
             throw new ArgumentException("Unsupported representation type for tessellation, " + shape.GetType().Name);
         }
 
-
         public XbimShapeGeometry Mesh(IIfcFaceBasedSurfaceModel faceBasedModel)
         {
             var faceSets = new List<IList<IIfcFace>>();
             foreach (var faceSet in faceBasedModel.FbsmFaces)
                 faceSets.Add(faceSet.CfsFaces.ToList());
-            return Mesh(faceSets, faceBasedModel.EntityLabel, (float)faceBasedModel.Model.ModelFactors.Precision);
+            return Mesh(faceSets, faceBasedModel.EntityLabel, (float)faceBasedModel.Model.ModelFactors.Precision, false);
         }
-
-
 
         public XbimShapeGeometry Mesh(IIfcShellBasedSurfaceModel shellBasedModel)
         {
@@ -86,27 +85,27 @@ namespace Xbim.Tessellator
                 if (closedShell != null) shells.Add(closedShell.CfsFaces.ToList());
                 else if (openShell != null) shells.Add(openShell.CfsFaces.ToList());
             }
-            return Mesh(shells, entityLabel, precision);
+            return Mesh(shells, entityLabel, precision, false);
         }
 
-        public XbimShapeGeometry Mesh(IIfcConnectedFaceSet connectedFaceSet)
+        public XbimShapeGeometry Mesh(IIfcConnectedFaceSet connectedFaceSet, bool isIntentiallyClosed)
         {
             var faces = new List<IList<IIfcFace>>();
             faces.Add(connectedFaceSet.CfsFaces.ToList());
-            return Mesh(faces, connectedFaceSet.EntityLabel, (float)connectedFaceSet.Model.ModelFactors.Precision);
+            return Mesh(faces, connectedFaceSet.EntityLabel, (float)connectedFaceSet.Model.ModelFactors.Precision, isIntentiallyClosed);
         }
 
         public XbimShapeGeometry Mesh(IIfcFacetedBrep fBRepModel)
         {
-            return Mesh(fBRepModel.Outer);
+            return Mesh(fBRepModel.Outer, true);
         }
 
-        public XbimShapeGeometry Mesh(IEnumerable<IList<IIfcFace>> facesList, int entityLabel, float precision)
+        public XbimShapeGeometry Mesh(IEnumerable<IList<IIfcFace>> facesList, int entityLabel, float precision, bool isIntentiallyClosed)
         {
             if (_geometryType == XbimGeometryType.PolyhedronBinary)
-                return MeshPolyhedronBinary(facesList, entityLabel, precision);
+                return MeshPolyhedronBinary(facesList, entityLabel, precision, isIntentiallyClosed);
             if (_geometryType == XbimGeometryType.Polyhedron)
-                return MeshPolyhedronText(facesList, entityLabel, precision);
+                return MeshPolyhedronText(facesList, entityLabel, precision, isIntentiallyClosed);
             throw new Exception("Illegal Geometry type, " + _geometryType);
         }
 
@@ -132,167 +131,95 @@ namespace Xbim.Tessellator
         {
             throw new NotImplementedException();
         }
+
         private XbimShapeGeometry MeshPolyhedronText(IIfcPolygonalFaceSet triangulation)
         {
             throw new NotImplementedException();
         }
+
         private XbimShapeGeometry MeshPolyhedronBinary(IIfcPolygonalFaceSet tess)
         {
             var faces = new List<IList<IIfcFace>>();
             faces.Add(new XbimPolygonalFaceSet(tess));
-            return Mesh(faces, tess.EntityLabel, (float)tess.Model.ModelFactors.Precision);
+            return Mesh(faces, tess.EntityLabel, (float)tess.Model.ModelFactors.Precision, tess.Closed ?? false);
         }
 
         private XbimShapeGeometry MeshPolyhedronBinary(IIfcTriangulatedFaceSet triangulation)
         {
+            var mesh = Triangulate(triangulation);
+            return ToBinaryShapeGeometry(mesh);
+        }
 
+        private XbimShapeGeometry ToBinaryShapeGeometry(params XbimTriangulatedMesh[] meshes)
+        {
             XbimShapeGeometry shapeGeometry = new XbimShapeGeometry();
             shapeGeometry.Format = XbimGeometryType.PolyhedronBinary;
 
             using (var ms = new MemoryStream(0x4000))
             using (var binaryWriter = new BinaryWriter(ms))
             {
+                // Write out header
+                uint verticesCount = 0;
+                uint triangleCount = 0;
+                uint facesCount = 0;
+                var boundingBox = XbimRect3D.Empty;
+                bool isAllVolumeDefined = true;
 
-                // Prepare the header
-                uint verticesCount = (uint)triangulation.Coordinates.CoordList.Count();
-                uint triangleCount = (uint)triangulation.CoordIndex.Count();
-                uint facesCount = 1;//at the moment just write one face for all triangles, may change to support styed faces in future
-                shapeGeometry.BoundingBox = XbimRect3D.Empty;
-
-                //Write out the header
-                binaryWriter.Write((byte)1); //stream format version			
-                // ReSharper disable once RedundantCast
-
-                //now write out the faces
-                if (triangulation.Normals.Any()) //we have normals so obey them
+                foreach (var mesh in meshes)
                 {
-                    List<IEnumerable<IfcPositiveInteger>> normalIndex = new List<IEnumerable<IfcPositiveInteger>>();
-                    bool hasPnIndex = triangulation.PnIndex.Any();
-                    if (hasPnIndex)
-                    {
+                    verticesCount += mesh.VertexCount;
+                    triangleCount += mesh.TriangleCount;
+                    facesCount += (uint)mesh.Faces.Count;
+                    shapeGeometry.Volume += mesh.Volume;
+                    isAllVolumeDefined &= mesh.Volume.HasValue;
 
-                        if (triangulation.PnIndex is List<IItemSet<IfcPositiveInteger>>) //the list of triplets has not been flattened
-                        {
-                            foreach (var item in triangulation.PnIndex as List<IItemSet<IfcPositiveInteger>>)
-                            {
-                                normalIndex.Add(item);
-                            }
-
-                        }
-                        else
-                        {
-                            for (int i = 0; i < triangulation.PnIndex.Count; i += 3)
-                            {
-                                var item = new List<IfcPositiveInteger>() { triangulation.PnIndex[i], triangulation.PnIndex[i + 1], triangulation.PnIndex[i + 2] };
-                                normalIndex.Add(item);
-                            }
-                        }
-                    }
+                    if (boundingBox.IsEmpty)
+                        boundingBox = mesh.BoundingBox;
                     else
-                    {
-                        foreach (var item in triangulation.CoordIndex)
-                        {
-                            normalIndex.Add(item);
-                        }
-                    }
-                    binaryWriter.Write(verticesCount); //number of vertices
-                    binaryWriter.Write(triangleCount); //number of triangles
-
-                    XbimRect3D bb = XbimRect3D.Empty;
-                    // use first point as a local origin for large coordinates. It doesn't matter if
-                    // we use min, max or centroid for this.
-                    var origin = triangulation.Coordinates?.CoordList.FirstOrDefault()?.AsTriplet() ?? new XbimTriplet<IfcLengthMeasure>();
-                    var isLarge = IsLarge(origin.A) || IsLarge(origin.B) || IsLarge(origin.C);
-                    if (isLarge)
-                    {
-                        shapeGeometry.LocalShapeDisplacement = new XbimVector3D(origin.A, origin.B, origin.C);
-                    }
-
-                    var points = isLarge ?
-                        triangulation.Coordinates.CoordList.Select(c => c.AsTriplet()).Select(t => new XbimTriplet<IfcLengthMeasure> { A = t.A - origin.A, B = t.B - origin.B, C = t.C - origin.C }) :
-                        triangulation.Coordinates.CoordList.Select(c => c.AsTriplet());
-                    foreach (var pt in points)
-                    {
-                        binaryWriter.Write((float)pt.A);
-                        binaryWriter.Write((float)pt.B);
-                        binaryWriter.Write((float)pt.C);
-
-                        var rect = new XbimRect3D(pt.A, pt.B, pt.C, 0, 0, 0);
-                        bb.Union(rect);
-                    }
-
-                    binaryWriter.Write(facesCount);
-
-                    shapeGeometry.BoundingBox = bb;
-                    Int32 numTrianglesInFace = triangulation.CoordIndex.Count();
-                    binaryWriter.Write(-numTrianglesInFace); //not a planar face so make negative 
-                    var packedNormals = new List<XbimPackedNormal>(triangulation.Normals.Count());
-                    foreach (var normal in triangulation.Normals)
-                    {
-                        var tpl = normal.AsTriplet<IfcParameterValue>();
-                        packedNormals.Add(new XbimPackedNormal(tpl.A, tpl.B, tpl.C));
-                    }
-
-
-
-
-                    int triangleIndex = 0;
-
-                    foreach (var triangle in triangulation.CoordIndex)
-                    {
-                        var triangleTpl = triangle.AsTriplet();
-                        var normalsIndexTpl = normalIndex[triangleIndex].AsTriplet();
-
-
-                        WriteIndex(binaryWriter, (uint)triangleTpl.A - 1, (uint)verticesCount);
-                        packedNormals[(int)normalsIndexTpl.A - 1].Write(binaryWriter);
-
-                        WriteIndex(binaryWriter, (uint)triangleTpl.B - 1, (uint)verticesCount);
-                        packedNormals[(int)normalsIndexTpl.B - 1].Write(binaryWriter);
-
-                        WriteIndex(binaryWriter, (uint)triangleTpl.C - 1, (uint)verticesCount);
-                        packedNormals[(int)normalsIndexTpl.C - 1].Write(binaryWriter);
-                        triangleIndex++;
-                    }
-
+                        boundingBox.Union(mesh.BoundingBox);
                 }
-                else //we need to calculate normals to get a better surface fit
+
+                if (!isAllVolumeDefined)
+                    // Reset, if there are non-closed bodies within the collection
+                    shapeGeometry.Volume = null;
+
+                binaryWriter.Write((byte)1); //stream format version			
+                                             // ReSharper disable once RedundantCast
+                binaryWriter.Write((UInt32)verticesCount); //number of vertices
+                binaryWriter.Write(triangleCount); //number of triangles
+
+                // use minimum bbox as a local origin
+                var origin = boundingBox.Min;
+                var isLarge = IsLarge(origin.X) || IsLarge(origin.Y) || IsLarge(origin.Z);
+
+                var vertices = isLarge ?
+                    meshes.SelectMany(t => t.Vertices).Select(v => new Vec3(v.X - origin.X, v.Y - origin.Y, v.Z - origin.Z)) :
+                    meshes.SelectMany(t => t.Vertices);
+
+                foreach (var v in vertices)
                 {
-                    var triangulatedMesh = Triangulate(triangulation);
-                    verticesCount = triangulatedMesh.VertexCount;
-                    triangleCount = triangulatedMesh.TriangleCount;
+                    binaryWriter.Write((float)v.X);
+                    binaryWriter.Write((float)v.Y);
+                    binaryWriter.Write((float)v.Z);
+                }
 
-                    binaryWriter.Write(verticesCount); //number of vertices
-                    binaryWriter.Write(triangleCount); //number of triangles
+                if (isLarge)
+                {
+                    var bb = boundingBox;
+                    shapeGeometry.BoundingBox = new XbimRect3D(bb.X - origin.X, bb.Y - origin.Y, bb.Z - origin.Z, bb.SizeX, bb.SizeY, bb.SizeZ);
+                    shapeGeometry.LocalShapeDisplacement = new XbimVector3D(origin.X, origin.Y, origin.Z);
+                }
+                else
+                {
+                    shapeGeometry.BoundingBox = boundingBox;
+                }
 
-                    // use minimum bbox as a local origin
-                    var origin = triangulatedMesh.BoundingBox.Min;
-                    var isLarge = IsLarge(origin.X) || IsLarge(origin.Y) || IsLarge(origin.Z);
-
-                    var vertices = isLarge ?
-                        triangulatedMesh.Vertices.Select(v => new Vec3(v.X - origin.X, v.Y - origin.Y, v.Z - origin.Z)) :
-                        triangulatedMesh.Vertices;
-                    foreach (var vert in vertices)
-                    {
-                        binaryWriter.Write((float)vert.X);
-                        binaryWriter.Write((float)vert.Y);
-                        binaryWriter.Write((float)vert.Z);
-                    }
-
-                    if (isLarge)
-                    {
-                        var bb = triangulatedMesh.BoundingBox;
-                        shapeGeometry.BoundingBox = new XbimRect3D(bb.X - origin.X, bb.Y - origin.Y, bb.Z - origin.Z, bb.SizeX, bb.SizeY, bb.SizeZ);
-                        shapeGeometry.LocalShapeDisplacement = new XbimVector3D(origin.X, origin.Y, origin.Z);
-                    }
-                    else
-                    {
-                        shapeGeometry.BoundingBox = triangulatedMesh.BoundingBox;
-                    }
-
-                    facesCount = (uint)triangulatedMesh.Faces.Count;
-                    binaryWriter.Write((UInt32)facesCount);
-                    foreach (var faceGroup in triangulatedMesh.Faces)
+                // Write faces
+                binaryWriter.Write(facesCount);
+                uint verticesOffset = 0;
+                foreach (var mesh in meshes)
+                {
+                    foreach (var faceGroup in mesh.Faces)
                     {
                         var numTrianglesInFace = faceGroup.Value.Count;
                         //we need to fix this
@@ -310,69 +237,72 @@ namespace Xbim.Tessellator
                                 triangle[0].PackedNormal.Write(binaryWriter);
                                 first = false;
                             }
-                            WriteIndex(binaryWriter, (uint)triangle[0].StartVertexIndex, verticesCount);
-                            if (!planar) triangle[0].PackedNormal.Write(binaryWriter);
-
-                            WriteIndex(binaryWriter, (uint)triangle[0].NextEdge.StartVertexIndex, verticesCount);
-                            if (!planar) triangle[0].NextEdge.PackedNormal.Write(binaryWriter);
-
-                            WriteIndex(binaryWriter, (uint)triangle[0].NextEdge.NextEdge.StartVertexIndex, verticesCount);
-                            if (!planar) triangle[0].NextEdge.NextEdge.PackedNormal.Write(binaryWriter);
+                            WriteIndex(binaryWriter, (uint)triangle[0].StartVertexIndex + verticesOffset, verticesCount);
+                            if (!planar)
+                                triangle[0].PackedNormal.Write(binaryWriter);
+                            WriteIndex(binaryWriter, (uint)triangle[0].NextEdge.StartVertexIndex + verticesOffset, verticesCount);
+                            if (!planar) 
+                                triangle[0].NextEdge.PackedNormal.Write(binaryWriter);
+                            WriteIndex(binaryWriter, (uint)triangle[0].NextEdge.NextEdge.StartVertexIndex + verticesOffset, verticesCount);
+                            if (!planar) 
+                                triangle[0].NextEdge.NextEdge.PackedNormal.Write(binaryWriter);
                         }
                     }
+                    verticesOffset += mesh.VertexCount;
                 }
                 binaryWriter.Flush();
                 ((IXbimShapeGeometryData)shapeGeometry).ShapeData = ms.ToArray();
             }
             return shapeGeometry;
-
         }
 
-        private bool IsLarge(double coordinate)
-        {
-            return coordinate > _model.ModelFactors.OneMilliMeter * 999999;
-        }
-
-        private XbimShapeGeometry MeshPolyhedronText(IEnumerable<IList<IIfcFace>> facesList, int entityLabel, float precision)
+        private XbimShapeGeometry ToTextShapeGeometry(params XbimTriangulatedMesh[] meshes)
         {
             var shapeGeometry = new XbimShapeGeometry();
             shapeGeometry.Format = XbimGeometryType.Polyhedron;
+
             using (var ms = new MemoryStream(0x4000))
             using (TextWriter textWriter = new StreamWriter(ms))
             {
-                var faceLists = facesList.ToList();
-                var triangulations = new List<XbimTriangulatedMesh>(faceLists.Count);
-                foreach (var faceList in faceLists)
-                    triangulations.Add(TriangulateFaces(faceList, entityLabel, precision));
-
                 // Write out header
                 uint verticesCount = 0;
                 uint triangleCount = 0;
                 uint facesCount = 0;
                 var boundingBox = XbimRect3D.Empty;
-                foreach (var triangulatedMesh in triangulations)
+                bool isAllVolumeDefined = true;
+
+                foreach (var mesh in meshes)
                 {
-                    verticesCount += triangulatedMesh.VertexCount;
-                    triangleCount += triangulatedMesh.TriangleCount;
-                    facesCount += (uint)triangulatedMesh.Faces.Count;
-                    if (boundingBox.IsEmpty) boundingBox = triangulatedMesh.BoundingBox;
-                    else boundingBox.Union(triangulatedMesh.BoundingBox);
+                    verticesCount += mesh.VertexCount;
+                    triangleCount += mesh.TriangleCount;
+                    facesCount += (uint)mesh.Faces.Count;
+                    shapeGeometry.Volume += mesh.Volume;
+                    isAllVolumeDefined &= mesh.Volume.HasValue;
+
+                    if (boundingBox.IsEmpty)
+                        boundingBox = mesh.BoundingBox;
+                    else
+                        boundingBox.Union(mesh.BoundingBox);
                 }
+
+                if (!isAllVolumeDefined)
+                    // Reset, if there are non-closed bodies within the collection
+                    shapeGeometry.Volume = null;
 
                 textWriter.WriteLine("P {0} {1} {2} {3} {4}", 2, verticesCount, facesCount, triangleCount, 0);
                 //write out vertices and normals  
                 textWriter.Write("V");
 
-                foreach (var p in triangulations.SelectMany(t => t.Vertices))
+                foreach (var p in meshes.SelectMany(t => t.Vertices))
                     textWriter.Write(" {0},{1},{2}", p.X, p.Y, p.Z);
 
                 textWriter.WriteLine();
 
                 //now write out the faces
                 uint verticesOffset = 0;
-                foreach (var triangulatedMesh in triangulations)
+                foreach (var mesh in meshes)
                 {
-                    foreach (var faceGroup in triangulatedMesh.Faces)
+                    foreach (var faceGroup in mesh.Faces)
                     {
                         textWriter.Write("T");
                         int currentNormal = -1;
@@ -406,120 +336,47 @@ namespace Xbim.Tessellator
                         }
                         textWriter.WriteLine();
                     }
-                    verticesOffset += triangulatedMesh.VertexCount;
+                    verticesOffset += mesh.VertexCount;
                 }
                 textWriter.Flush();
                 shapeGeometry.BoundingBox = boundingBox;
                 ((IXbimShapeGeometryData)shapeGeometry).ShapeData = ms.ToArray();
             }
             return shapeGeometry;
+
         }
 
-        private XbimShapeGeometry MeshPolyhedronBinary(IEnumerable<IList<IIfcFace>> facesList, int entityLabel, float precision)
+        private bool IsLarge(double coordinate)
         {
-            XbimShapeGeometry shapeGeometry = new XbimShapeGeometry();
-            shapeGeometry.Format = XbimGeometryType.PolyhedronBinary;
-
-            using (var ms = new MemoryStream(0x4000))
-            using (var binaryWriter = new BinaryWriter(ms))
-            {
-                var faceLists = facesList.ToList();
-                var triangulatedMeshes = new List<XbimTriangulatedMesh>(faceLists.Count);
-                foreach (var faceList in faceLists)
-                {
-                    triangulatedMeshes.Add(TriangulateFaces(faceList, entityLabel, precision));
-                }
-
-                // Write out header
-                uint verticesCount = 0;
-                uint triangleCount = 0;
-                uint facesCount = 0;
-                var boundingBox = XbimRect3D.Empty;
-                foreach (var triangulatedMesh in triangulatedMeshes)
-                {
-                    verticesCount += triangulatedMesh.VertexCount;
-                    triangleCount += triangulatedMesh.TriangleCount;
-                    facesCount += (uint)triangulatedMesh.Faces.Count;
-                    if (boundingBox.IsEmpty)
-                        boundingBox = triangulatedMesh.BoundingBox;
-                    else
-                        boundingBox.Union(triangulatedMesh.BoundingBox);
-                }
-
-                binaryWriter.Write((byte)1); //stream format version			
-                                             // ReSharper disable once RedundantCast
-                binaryWriter.Write((UInt32)verticesCount); //number of vertices
-                binaryWriter.Write(triangleCount); //number of triangles
-
-                // use minimum bbox as a local origin
-                var origin = boundingBox.Min;
-                var isLarge = IsLarge(origin.X) || IsLarge(origin.Y) || IsLarge(origin.Z);
-
-                var vertices = isLarge ?
-                    triangulatedMeshes.SelectMany(t => t.Vertices).Select(v => new Vec3(v.X - origin.X, v.Y - origin.Y, v.Z - origin.Z)):
-                    triangulatedMeshes.SelectMany(t => t.Vertices);
-                foreach (var v in vertices)
-                {
-                    binaryWriter.Write((float)v.X);
-                    binaryWriter.Write((float)v.Y);
-                    binaryWriter.Write((float)v.Z);
-                }
-                if (isLarge)
-                {
-                    var bb = boundingBox;
-                    shapeGeometry.BoundingBox = new XbimRect3D(bb.X - origin.X, bb.Y - origin.Y, bb.Z - origin.Z, bb.SizeX, bb.SizeY, bb.SizeZ);
-                    shapeGeometry.LocalShapeDisplacement = new XbimVector3D(origin.X, origin.Y, origin.Z);
-                }
-                else
-                {
-                    shapeGeometry.BoundingBox = boundingBox;
-                }
-
-
-                //now write out the faces
-
-                binaryWriter.Write(facesCount);
-                uint verticesOffset = 0;
-                int invalidNormal = ushort.MaxValue;
-                foreach (var triangulatedMesh in triangulatedMeshes)
-                {
-                    foreach (var faceGroup in triangulatedMesh.Faces)
-                    {
-                        var numTrianglesInFace = faceGroup.Value.Count;
-                        //we need to fix this
-                        var planar = invalidNormal != faceGroup.Key; //we have a mesh of faces that all have the same normals at their vertices
-                        if (!planar) numTrianglesInFace *= -1; //set flag to say multiple normals
-
-                        // ReSharper disable once RedundantCast
-                        binaryWriter.Write((Int32)numTrianglesInFace);
-
-                        bool first = true;
-                        foreach (var triangle in faceGroup.Value)
-                        {
-                            if (planar && first)
-                            {
-                                triangle[0].PackedNormal.Write(binaryWriter);
-                                first = false;
-                            }
-                            WriteIndex(binaryWriter, (uint)triangle[0].StartVertexIndex + verticesOffset, verticesCount);
-                            if (!planar)
-                                triangle[0].PackedNormal.Write(binaryWriter);
-                            WriteIndex(binaryWriter, (uint)triangle[0].NextEdge.StartVertexIndex + verticesOffset, verticesCount);
-                            if (!planar) triangle[0].NextEdge.PackedNormal.Write(binaryWriter);
-                            WriteIndex(binaryWriter, (uint)triangle[0].NextEdge.NextEdge.StartVertexIndex + verticesOffset,
-                                verticesCount);
-                            if (!planar) triangle[0].NextEdge.NextEdge.PackedNormal.Write(binaryWriter);
-                        }
-                    }
-                    verticesOffset += triangulatedMesh.VertexCount;
-                }
-                binaryWriter.Flush();
-                ((IXbimShapeGeometryData)shapeGeometry).ShapeData = ms.ToArray();
-            }
-            return shapeGeometry;
+            return coordinate > _model.ModelFactors.OneMilliMeter * 999999;
         }
 
-        private XbimTriangulatedMesh TriangulateFaces(IList<IIfcFace> ifcFaces, int entityLabel, float precision)
+        private XbimShapeGeometry MeshPolyhedronText(IEnumerable<IList<IIfcFace>> facesList, int entityLabel, float precision, bool isIntentionallyClosed)
+        {
+            var meshes = new XbimTriangulatedMesh[facesList.Count()];
+            int index = 0;
+            foreach (var faceList in facesList)
+            {
+                meshes[index] = TriangulateFaces(faceList, entityLabel, precision, isIntentionallyClosed);
+                index++;
+            }
+
+            return ToTextShapeGeometry(meshes);
+        }
+
+        private XbimShapeGeometry MeshPolyhedronBinary(IEnumerable<IList<IIfcFace>> facesList, int entityLabel, float precision, bool isIntentionallyClosed)
+        {
+            var meshes = new XbimTriangulatedMesh[facesList.Count()];
+            int index = 0;
+            foreach (var faceList in facesList)
+            {
+                meshes[index] = TriangulateFaces(faceList, entityLabel, precision, isIntentionallyClosed);
+                index++;
+            }
+            return ToBinaryShapeGeometry(meshes);
+        }
+
+        private XbimTriangulatedMesh TriangulateFaces(IList<IIfcFace> ifcFaces, int entityLabel, float precision, bool isIntentiallyClosed)
         {
             var faceId = 0;
 
@@ -527,19 +384,18 @@ namespace Xbim.Tessellator
             var triangulatedMesh = new XbimTriangulatedMesh(faceCount, precision);
             foreach (var ifcFace in ifcFaces)
             {
-
-                //improves performance and reduces memory load
+                // improves performance and reduces memory load
                 var tess = new Tess();
 
                 var contours = new List<ContourVertex[]>(/*Count?*/);
-                foreach (var bound in ifcFace.Bounds) //build all the loops
+                foreach (var bound in ifcFace.Bounds) // build all the loops
                 {
                     var polyLoop = bound.Bound as IIfcPolyLoop;
 
-                    if (polyLoop == null) continue; //skip empty faces
+                    if (polyLoop == null) continue; // skip empty faces
                     var polygon = polyLoop.Polygon;
 
-                    if (polygon.Count < 3) continue; //skip non-polygonal faces
+                    if (polygon.Count < 3) continue; // skip non-polygonal faces
                     var is3D = (polygon[0].Dim == 3);
 
                     var contour = new ContourVertex[polygon.Count];
@@ -566,25 +422,12 @@ namespace Xbim.Tessellator
 
                 if (contours.Any())
                 {
-                    if (contours.Count == 1 && contours[0].Length == 3) //its a triangle just grab it
+                    if (contours.Count == 1 && contours[0].Length == 3) // its a triangle just grab it
                     {
                         triangulatedMesh.AddTriangle(contours[0][0].Data, contours[0][1].Data, contours[0][2].Data, faceId);
                         faceId++;
                     }
-                    //else 
-                    //if (contours.Count == 1 && contours[0].Length == 4) //its a quad just grab it
-                    //{
-                    //    foreach (var v in contours[0])
-                    //    {
-                    //        Console.WriteLine("{0:F4} ,{1:F4}, {2:F4}", v.Position.X, v.Position.Y, v.Position.Z);
-
-                    //    }
-                    //    Console.WriteLine("");
-                    //    triangulatedMesh.AddTriangle(contours[0][0].Data, contours[0][1].Data, contours[0][3].Data, faceId);
-                    //    triangulatedMesh.AddTriangle(contours[0][3].Data, contours[0][1].Data, contours[0][2].Data, faceId);
-                    //    faceId++;
-                    //}
-                    else    //it is multi-sided and may have holes
+                    else  // it is multi-sided and may have holes
                     {
                         tess.AddContours(contours);
 
@@ -618,20 +461,73 @@ namespace Xbim.Tessellator
                 }
             }
 
-            triangulatedMesh.UnifyFaceOrientation(entityLabel);
+            var status = triangulatedMesh.UnifyMeshOrientation(isIntentiallyClosed, true);
+            ReportStatus(entityLabel, triangulatedMesh.Validate(status));
+            
             return triangulatedMesh;
         }
 
+        private void ReportStatus(int entityLabel, XbimTriangulationStatus status)
+        {
+            if (XbimTriangulationStatus.NoIssues != (status & ReportMask))
+            {
+                List<string> issueText = new List<string>();
+
+                if (XbimTriangulationStatus.IsOpenBody == (XbimTriangulationStatus.IsOpenBody & status))
+                    issueText.Add("has open body");
+
+                if (XbimTriangulationStatus.WasInvertedBody == (XbimTriangulationStatus.WasInvertedBody & status))
+                    issueText.Add("has been inverted to reflect a positive volume");
+
+                if (XbimTriangulationStatus.HasFaultyTriangles == (XbimTriangulationStatus.HasFaultyTriangles & status))
+                    issueText.Add("contains unconnected or faulty triangles not displayed");
+
+                _logger.LogWarning("Shape validation result of #{0}: {1}", entityLabel, string.Join(", ", issueText));
+            }
+        }
 
         private XbimTriangulatedMesh Triangulate(IIfcTriangulatedFaceSet triangulation)
         {
-            var faceId = 0;
-            var entityLabel = triangulation.EntityLabel;
+            // Use a single face only
+            const int faceId = 0;
+
             var precision = (float)triangulation.Model.ModelFactors.Precision;
             var faceCount = triangulation.CoordIndex.Count();
             var triangulatedMesh = new XbimTriangulatedMesh(faceCount, precision);
-            //add all the vertices in to the mesh
+            // Add all the vertices in to the mesh
             var vertices = new List<int>(triangulation.Coordinates.CoordList.Count());
+
+            // If normals are provided
+            List<XbimTriplet<IfcParameterValue>> nTriplets = triangulation.Normals.Select(n => n.AsTriplet<IfcParameterValue>()).ToList();
+            List<IEnumerable<IfcPositiveInteger>> normalIndex = new List<IEnumerable<IfcPositiveInteger>>();
+            bool hasPnIndex = triangulation.PnIndex.Any();
+            if (hasPnIndex)
+            {
+                if (triangulation.PnIndex is List<IItemSet<IfcPositiveInteger>>) //the list of triplets has not been flattened
+                {
+                    foreach (var item in triangulation.PnIndex as List<IItemSet<IfcPositiveInteger>>)
+                    {
+                        normalIndex.Add(item);
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < triangulation.PnIndex.Count; i += 3)
+                    {
+                        var item = new List<IfcPositiveInteger>() { triangulation.PnIndex[i], triangulation.PnIndex[i + 1], triangulation.PnIndex[i + 2] };
+                        normalIndex.Add(item);
+                    }
+                }
+            }
+            else
+            {
+                foreach (var item in triangulation.CoordIndex)
+                {
+                    normalIndex.Add(item);
+                }
+            }
+
+            // Add coordinates
             foreach (var coord in triangulation.Coordinates.CoordList)
             {
                 var tpl = coord.AsTriplet<IfcLengthMeasure>();
@@ -639,15 +535,40 @@ namespace Xbim.Tessellator
                 var idx = triangulatedMesh.AddVertex(v);
                 vertices.Add(idx);
             }
+
+            // Create triangles
+            int tIndex = 0;
             foreach (var triangleFace in triangulation.CoordIndex)
             {
                 var tpl = triangleFace.AsTriplet<IfcPositiveInteger>();
-                triangulatedMesh.AddTriangle(vertices[(int)tpl.A - 1], vertices[(int)tpl.B - 1], vertices[(int)tpl.C - 1], faceId);
+                var edges = triangulatedMesh.AddTriangle(vertices[(int)tpl.A - 1], vertices[(int)tpl.B - 1], vertices[(int)tpl.C - 1], faceId);
+
+                // If there are normals given
+                if (nTriplets.Count > 0)
+                {
+                    var normalsIndexTpl = normalIndex[tIndex].AsTriplet();
+                    // Use given normals
+                    edges[0].Normal = new Vec3(nTriplets[(int)normalsIndexTpl.A - 1]);
+                    edges[1].Normal = new Vec3(nTriplets[(int)normalsIndexTpl.B - 1]);
+                    edges[2].Normal = new Vec3(nTriplets[(int)normalsIndexTpl.C - 1]);
+                }
+
+                tIndex++;
             }
-            triangulatedMesh.UnifyFaceOrientation(entityLabel);
+
+            // If not marked as closed, don't go for orientation alignment
+            XbimTriangulationStatus? status = null;
+            if (triangulation.Closed ?? false)
+                // It makes no sense to align a mesh which isn't meant to have an orientation
+                status = triangulatedMesh.UnifyMeshOrientation(true, nTriplets.Count == 0);
+            else
+                // So only balance normals (and if not provided already, compute normals)
+                triangulatedMesh.BalanceNormals(nTriplets.Count == 0);
+
+            ReportStatus(triangulation.EntityLabel, triangulatedMesh.Validate(status));
+
             return triangulatedMesh;
         }
-
 
         private void WriteIndex(BinaryWriter bw, UInt32 index, UInt32 maxInt)
         {
@@ -658,7 +579,5 @@ namespace Xbim.Tessellator
             else
                 bw.Write(index);
         }
-
-
     }
 }


### PR DESCRIPTION
I've got the same trouble as mentioned in xBimTeam/XbimGeometry#96. So I've started to investigate the problem and found the reason. The former orientation alignment / reverse algorithm wasn't stable for all types of bodies (especially with concave shapes near the boundaries).

Improves the tessellation and especially the orientation alignment algorithm of the triangulations. It now computes the approximated tetrahedral volume and reverse the mesh orientation, if the volume is negative. It also refactors the implementation. It also adds a volume value to the shape data holder for validation purpose. 
Will also require a PR on geometry side.