### PR TITLE
Fixing  xBimTeam/XbimWindowsUI#145 unique property set name constraint

### DIFF
--- a/Xbim.Ifc4/IfcFunctions/Functions.cs
+++ b/Xbim.Ifc4/IfcFunctions/Functions.cs
@@ -527,8 +527,9 @@ namespace Xbim.Ifc4
 
         internal static bool IfcUniqueDefinitionNames(IEnumerable<IfcRelDefinesByProperties> RelDefinesByProperties)
         {
-            var values = RelDefinesByProperties.Select(x => x.Name).ToList();
-            var isUnique = values.Distinct().Count() == RelDefinesByProperties.Count();
+            var values = RelDefinesByProperties.SelectMany(r => 
+                r.RelatingPropertyDefinition.PropertySetDefinitions.Select(x => x.Name)).ToList();
+            var isUnique = values.Distinct().Count() == values.Count();
             return isUnique; 
         }
 


### PR DESCRIPTION
The function wasn't correct. It took the name of the relation instead of the property set.