### PR TITLE
fix (XbimMatrix3D): matrix direction vectors accessors to be evaluated from the public cell elements public getters

### DIFF
--- a/Tests/GeometryTests.cs
+++ b/Tests/GeometryTests.cs
@@ -30,6 +30,38 @@ namespace Xbim.Essentials.Tests
         }
 
         [TestMethod]
+        public void MatrixTests()
+        {
+            var m = new XbimMatrix3D();
+
+            Assert.AreEqual(XbimMatrix3D.Identity.Up, m.Up, "Uninitialised matrix Up vector is equal to identity's.");
+            Assert.AreEqual(XbimMatrix3D.Identity.Right, m.Right, "Uninitialised matrix Right vector is equal to identity's.");
+            Assert.AreEqual(XbimMatrix3D.Identity.Forward, m.Forward, "Uninitialised matrix Forward vector is equal to identity's.");
+
+            var _ = m.M21; // randomly accessing on of matrix' elements
+
+            // Vectors assertions should pass
+            Assert.AreEqual(XbimMatrix3D.Identity.Up, m.Up, "Up vector is equal to identity's after matrix' cell access.");
+            Assert.AreEqual(XbimMatrix3D.Identity.Right, m.Right, "Right vector is equal to identity's after matrix' cell access.");
+            Assert.AreEqual(XbimMatrix3D.Identity.Forward, m.Forward, "Forward vector is equal to identity's after matrix' cell access.");
+
+
+            m = new XbimMatrix3D(XbimVector3D.Zero);
+
+            Assert.AreEqual(XbimMatrix3D.Identity.Up, m.Up, "Matrix initialized with Zero vector - Up vector is equal to identity's.");
+            Assert.AreEqual(XbimMatrix3D.Identity.Right, m.Right, "Matrix initialized with Zero vector - Right vector is equal to identity's.");
+            Assert.AreEqual(XbimMatrix3D.Identity.Forward, m.Forward, "Matrix initialized with Zero vector - Forward vector is equal to identity's.");
+
+            _ = m.M21;
+
+            Assert.AreEqual(XbimMatrix3D.Identity.Up, m.Up, "Up vector is equal to identity's after matrix' cell access.");
+            Assert.AreEqual(XbimMatrix3D.Identity.Right, m.Right, "Right vector is equal to identity's after matrix' cell access.");
+            Assert.AreEqual(XbimMatrix3D.Identity.Forward, m.Forward, "Forward vector is equal to identity's after matrix' cell access.");
+
+
+        }
+
+        [TestMethod]
         public void PackedNormalTests()
         {
             var vectors = (List<XbimVector3D>)UniformPointsOnSphere(100);

--- a/Xbim.Common/Geometry/XbimMatrix3D.cs
+++ b/Xbim.Common/Geometry/XbimMatrix3D.cs
@@ -454,7 +454,7 @@ namespace Xbim.Common.Geometry
         {
             get
             {
-                return new XbimVector3D(_m21, _m22, _m23);
+                return new XbimVector3D(M21, M22, M23);
             }
         }
 
@@ -463,7 +463,7 @@ namespace Xbim.Common.Geometry
         {
             get
             {
-                return new XbimVector3D(-_m21, -_m22,-_m23);
+                return new XbimVector3D(-M21, -M22,-M23);
             }
         }
 
@@ -472,7 +472,7 @@ namespace Xbim.Common.Geometry
         {
             get
             {
-                return new XbimVector3D(_m11, _m12, _m13);
+                return new XbimVector3D(M11, M12, M13);
             }
         }
 
@@ -481,7 +481,7 @@ namespace Xbim.Common.Geometry
         {
             get
             {
-                return new XbimVector3D(-_m11, -_m12, -_m13);
+                return new XbimVector3D(-M11, -M12, -M13);
             }
         }
 
@@ -490,7 +490,7 @@ namespace Xbim.Common.Geometry
         {
             get
             {
-                return new XbimVector3D(-_m31, -_m32, -_m33);
+                return new XbimVector3D(-M31, -M32, -M33);
             }
         }
 
@@ -499,7 +499,7 @@ namespace Xbim.Common.Geometry
         {
             get
             {
-                return new XbimVector3D(_m31, _m32, _m33);
+                return new XbimVector3D(M31, M32, M33);
             }
         }
 


### PR DESCRIPTION
This PR fixes this issue [395 ](https://github.com/xBimTeam/XbimGeometry/issues/395) in XbimGeometry repository.

**Problem**:
The direction vectors (Up, Right...etc.) were evaluated from the backing fields of the cell elements (_m11, _m12...etc.) and this had an issue when having a default initialized matrix as those backing fields wouldn't be initialized by the identity matrix values until  accessing the public getters of the matrix main diagonal (M11, M22, M33).

**Solution**:
The direction vectors (Up, Right...etc.) made to be evaluated directly from the cell elements public getters, which will guarantee at least one of the main diagonal elements is invoked and allows for the identity-initialization to take place.

- [x] Name of this PR is aligned with the name the story.
- [x] It compiles and runs for everybody.
- [x] New code is covered by tests
- [x] All tests run and pass
- [x] Code is readable
- [x] Amount of changes is understandable
- [x] It does what is says it does. I have checked that.

