### PR TITLE
fix: ApplicationDevelopersName-mapping

### DIFF
--- a/Xbim.Ifc/IfcStore.cs
+++ b/Xbim.Ifc/IfcStore.cs
@@ -514,8 +514,8 @@ namespace Xbim.Ifc
                          (_defaultOwningApplication =
                              Instances.New<Ifc4.UtilityResource.IfcApplication>(a =>
                              {
-                                 a.ApplicationDeveloper = Instances.OfType<Ifc4.ActorResource.IfcOrganization>().FirstOrDefault(o => o.Name == EditorDetails.EditorsOrganisationName)
-                                 ?? Instances.New<Ifc4.ActorResource.IfcOrganization>(o => o.Name = EditorDetails.EditorsOrganisationName);
+                                 a.ApplicationDeveloper = Instances.OfType<Ifc4.ActorResource.IfcOrganization>().FirstOrDefault(o => o.Name == EditorDetails.ApplicationDevelopersName)
+                                 ?? Instances.New<Ifc4.ActorResource.IfcOrganization>(o => o.Name = EditorDetails.ApplicationDevelopersName);
                                  a.ApplicationFullName = EditorDetails.ApplicationFullName;
                                  a.ApplicationIdentifier = EditorDetails.ApplicationIdentifier;
                                  a.Version = EditorDetails.ApplicationVersion;
@@ -525,8 +525,8 @@ namespace Xbim.Ifc
                         (_defaultOwningApplication =
                             Instances.New<Ifc2x3.UtilityResource.IfcApplication>(a =>
                             {
-                                a.ApplicationDeveloper = Instances.OfType<Ifc2x3.ActorResource.IfcOrganization>().FirstOrDefault(o => o.Name == EditorDetails.EditorsOrganisationName)
-                                ?? Instances.New<Ifc2x3.ActorResource.IfcOrganization>(o => o.Name = EditorDetails.EditorsOrganisationName);
+                                a.ApplicationDeveloper = Instances.OfType<Ifc2x3.ActorResource.IfcOrganization>().FirstOrDefault(o => o.Name == EditorDetails.ApplicationDevelopersName)
+                                ?? Instances.New<Ifc2x3.ActorResource.IfcOrganization>(o => o.Name = EditorDetails.ApplicationDevelopersName);
                                 a.ApplicationFullName = EditorDetails.ApplicationFullName;
                                 a.ApplicationIdentifier = EditorDetails.ApplicationIdentifier;
                                 a.Version = EditorDetails.ApplicationVersion;


### PR DESCRIPTION
This PR solves issue #465

When using XbimEditorCredentials in the IfcStore constructor both "IfcApplication->ApplicationDeveloper" and "OwningUser->TheOrganization" for the "IfcOwnerHistory" point to the same "IfcOrganization" created from "EditorsOrganisationName".
I believe "IfcApplication->ApplicationDeveloper" should reference "ApplicationDevelopersName" instead.