### PR TITLE
Renamed Extension classes to avoid collisions in common namespaces

### DIFF
--- a/Xbim.Common/XbimServiceCollectionExtensions.cs
+++ b/Xbim.Common/XbimServiceCollectionExtensions.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Xbim.Common
 {
-    public static class ServiceCollectionExtensions
+    public static class XbimServiceCollectionExtensions
     {
        
 

--- a/Xbim.Essentials.tmpl
+++ b/Xbim.Essentials.tmpl
@@ -11,17 +11,17 @@
 		<iconUrl>https://avatars1.githubusercontent.com/u/2284875?v=3&amp;s=240</iconUrl>
 		<requireLicenseAcceptance>true</requireLicenseAcceptance>
 		<description>
-			xBIM Essentials 5 provides support for IFC2x2, IFC2x3, IFC4 Addendum 2 and IFC Alignment (IFC4x1).
+			xBIM Essentials provides support for IFC2x2, IFC2x3, IFC4 Addendum 2 and IFC Alignment (IFC4x1).
 			xBIM can open, create or modify any IFC file format, including XML, STEP21 and IFCZIP formats.
 			All programmatic access to IFC Entities is through a single interface, allowing one code base to work with all IFC formats and schemas.
 			Ifc4 is the default interface future proofing your development work.
 		</description>
-		<summary>Meta package for xBIM toolkit base libraries for work with IFC data.</summary>
+		<summary>The main package for xBIM toolkit base libraries for working with IFC data.</summary>
 		<releaseNotes>
-			Support for NetCore 3.1 added
-			This release is now a 'meta-package' which replaces Xbim Essentials v4. For more granular control you can include the individual Nuget packages in the dependencies.
-			This release is the first to target netstandard2, in addition to netfx. Only minor code refactoring might be required.
-			V5 of Essentials now targets .net47 as a minimum.
+			Support for Net6.0 and netstandard2.1 added
+			Support for Ifc4.3 TC1 schema
+			Support for Managed Esent under netcore (Windows only still) - Esent now included as core again
+			Updated to be Dependency Injection friendly
 		</releaseNotes>
 		<language>en-GB</language>
 		<tags>BIM IFC IfcXml IfcZip Ifc4  COBie .Net XBIM WexBIM BuildingSmart</tags>
@@ -31,6 +31,7 @@
 				<dependency id="Xbim.Ifc4" version="{{version}}" />
 				<dependency id="Xbim.Ifc2x3" version="{{version}}" />
 				<dependency id="Xbim.Ifc4x3" version="{{version}}" />
+				<dependency id="Xbim.IO.EsentModel" version="{{version}}" />
 				<dependency id="Xbim.IO.MemoryModel" version="{{version}}" />
 				<dependency id="Xbim.Ifc" version="{{version}}" />
 				<dependency id="Xbim.Tessellator" version="{{version}}" />
@@ -40,6 +41,7 @@
 				<dependency id="Xbim.Ifc4" version="{{version}}" />
 				<dependency id="Xbim.Ifc2x3" version="{{version}}" />
 				<dependency id="Xbim.Ifc4x3" version="{{version}}" />
+				<dependency id="Xbim.IO.EsentModel" version="{{version}}" />
 				<dependency id="Xbim.IO.MemoryModel" version="{{version}}" />
 				<dependency id="Xbim.Ifc" version="{{version}}" />
 				<dependency id="Xbim.Tessellator" version="{{version}}" />
@@ -49,6 +51,7 @@
 				<dependency id="Xbim.Ifc4" version="{{version}}" />
 				<dependency id="Xbim.Ifc2x3" version="{{version}}" />
 				<dependency id="Xbim.Ifc4x3" version="{{version}}" />
+				<dependency id="Xbim.IO.EsentModel" version="{{version}}" />
 				<dependency id="Xbim.IO.MemoryModel" version="{{version}}" />
 				<dependency id="Xbim.Ifc" version="{{version}}" />
 				<dependency id="Xbim.Tessellator" version="{{version}}" />

--- a/Xbim.IO.Esent/EsentModelProviderExtensions.cs
+++ b/Xbim.IO.Esent/EsentModelProviderExtensions.cs
@@ -6,7 +6,7 @@ using Xbim.IO.Esent;
 
 namespace Xbim.Ifc
 {
-    public static class ModelProviderExtensions
+    public static class EsentModelProviderExtensions
     {
         /// <summary>
         /// Configures the <see cref="IModelProviderFactory"/> to use the <see cref="HeuristicModelProvider"/>

--- a/Xbim.IO.MemoryModel/MemoryModelProviderExtensions.cs
+++ b/Xbim.IO.MemoryModel/MemoryModelProviderExtensions.cs
@@ -6,7 +6,7 @@ using Xbim.IO.Memory;
 
 namespace Xbim.Ifc
 {
-    public static class ModelProviderExtensions
+    public static class MemoryModelProviderExtensions
     {
         /// <summary>
         /// Configures the <see cref="IModelProviderFactory"/> to use the <see cref="MemoryModelProvider"/>

--- a/Xbim.IO.MemoryModel/MemoryModelServiceCollectionExtensions.cs
+++ b/Xbim.IO.MemoryModel/MemoryModelServiceCollectionExtensions.cs
@@ -1,13 +1,10 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
 using Xbim.Common.Configuration;
-using Xbim.IO;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Xbim.Ifc;
 
 namespace Xbim.Common
 {
-    public static class ServiceCollectionExtensions
+    public static class MemoryModelServiceCollectionExtensions
     {
         /// <summary>
         /// Adds xbim Toolkit IFC Model services to the specified <see cref="IServiceCollection"/>


### PR DESCRIPTION
Renamed Extension classes to avoid collisions in common namespaces : Causing issues in Geometry Managed project
Add EsentModel to Essentials package
Update package metadata