### PR TITLE
Ensure a modelProvider is always registered.

### DIFF
--- a/Tests/DependencyInjectionTests.cs
+++ b/Tests/DependencyInjectionTests.cs
@@ -52,6 +52,16 @@ namespace Xbim.Essentials.Tests
         }
 
         [Fact]
+        public void MemoryModelProvider_resolved_by_default_with_Config()
+        {
+            SuT.ConfigureServices(s => s.AddXbimToolkit(opt => opt.AddLoggerFactory(new LoggerFactory())));
+
+            var provider = SuT.ServiceProvider.GetRequiredService<IModelProvider>();
+            provider.Should().NotBeNull();
+            provider.Should().BeOfType<MemoryModelProvider>();
+        }
+
+        [Fact]
         public void MemoryModelProvider_can_be_added_explicitly()
         {
             SuT.ConfigureServices(s => s.AddXbimToolkit(opt => opt.AddMemoryModel()));
@@ -211,6 +221,27 @@ namespace Xbim.Essentials.Tests
             var service = SuT.ServiceProvider.GetRequiredService<IModelProvider>();
 
             service.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Services_Are_Registered_Once_Only()
+        {
+            var services = new ServiceCollection();
+            int count = 0;
+            
+            SuT.ConfigureServices(s => 
+            { 
+                s.AddXbimToolkit();
+                count = s.Count;
+            });
+
+            SuT.ConfigureServices(s =>
+            {
+                s.AddXbimToolkit();
+                s.Count.Should().Be(count);
+            });
+
+
         }
 
 

--- a/Xbim.IO.MemoryModel/MemoryModelServiceCollectionExtensions.cs
+++ b/Xbim.IO.MemoryModel/MemoryModelServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
 
-
 namespace Xbim.Common.Configuration
 {
     public static class MemoryModelServiceCollectionExtensions
@@ -13,7 +12,7 @@ namespace Xbim.Common.Configuration
         /// <returns>The <see cref="IServiceCollection"/> so additional calls can be chained</returns>
         public static IServiceCollection AddXbimToolkit(this IServiceCollection services)
         {
-            return services.AddXbimToolkit(o => o.AddMemoryModel());
+            return services.AddXbimToolkit(opt => { });
         }
 
         /// <summary>
@@ -24,8 +23,11 @@ namespace Xbim.Common.Configuration
         /// <returns>The <see cref="IServiceCollection"/> so additional calls can be chained</returns>
         public static IServiceCollection AddXbimToolkit(this IServiceCollection services, Action<IXbimConfigurationBuilder> configure)
         {
-                        
-            configure(new XbimConfigurationBuilder(services));
+            var builder = new XbimConfigurationBuilder(services);
+            configure(builder);
+            // Fall back to MemoryProvider if no IModelProvider specified
+            MemoryModelConfigurationBuilderExtensions.AddMemoryModel(builder);
+            
             return services;
         }
     }


### PR DESCRIPTION
Previously using the configuration builder would allow you to omit the implementation, meaning the IfcStore would fail to resolve a provider.

Now we always default the MemoryModel Provider when none is supplied.

TODO: Consider if we default Heuristic Provider?