### PR TITLE
fix: parsing large labels over int32.MaxValue caused a loop in the parser

### DIFF
--- a/Tests/ParsingTests.cs
+++ b/Tests/ParsingTests.cs
@@ -810,6 +810,14 @@ namespace Xbim.Essentials.Tests
         }
 
         [TestMethod]
+        public void Parsing_large_entity_label_doesnt_loop()
+        {
+            using var model = new IO.Memory.MemoryModel(ef2x3);
+            var errCount = model.LoadStep21("TestFiles\\Large_entity_label.ifc");
+            Assert.AreEqual(1, errCount);
+        }
+
+        [TestMethod]
         // this is a meta tast of the large stream mock-up
         public void LargeStreamTest()
         {

--- a/Tests/TestFiles/Large_entity_label.ifc
+++ b/Tests/TestFiles/Large_entity_label.ifc
@@ -1,0 +1,12 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('Project Number','2013-12-02T13:34:01',(''),(''),'The EXPRESS Data Manager Version 5.01.0100.02.64mod : 6 Jun 2012','20130722_2115(x64) - Exporter 2014.0.2013.0722 - Default UI','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+
+DATA;
+#92147483647=IFCORGANIZATION($,'Autodesk Revit 2014 (ENU)',$,$,$);
+ENDSEC;
+
+END-ISO-10303-21;

--- a/Xbim.Common/Step21/XbimP21Scanner.cs
+++ b/Xbim.Common/Step21/XbimP21Scanner.cs
@@ -272,6 +272,7 @@ namespace Xbim.IO.Step21
 
                     // scan until the beginning of next entity
                     var entityToken = (int)Tokens.ENTITY;
+                    tok = _scanner.yylex();
                     while (tok != eofToken && tok != entityToken)
                     {
                         tok = _scanner.yylex();
@@ -557,6 +558,9 @@ namespace Xbim.IO.Step21
                 // check if it is actually an integral number
                 if (component < 0 || component > 9)
                     continue;
+
+                if (order > magnitudes.Length - 1)
+                    throw new Exception($"Entity label #{value} is bigger than Int32.MaxValue");
 
                 label += component * magnitudes[order++];
             }


### PR DESCRIPTION
Toolkit currently reads entity labels as integers. This is for performance reasons as keeping all entity labels as long would increase amount of memory used by the applications considerably. Also, `Int32.MaxValue` provides enough space even for very large models. In the future, we may introduce internal parser time mapping to handle these special files.

In the current implementation, exception in label conversion caused a loop. This was only broken by maximum number of errors, but that is a week constraint and reported wrong number of issues. **This fix doesn't introduce support for long labels.**