### PR TITLE
Implemented means of reading IfcSchema from Streams including non-seekable streams

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <GenerateDocumentationFile Condition=" '$(IsTestProject)' != 'true' ">true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Tests/ReadSeekableStreamTests.cs
+++ b/Tests/ReadSeekableStreamTests.cs
@@ -1,0 +1,161 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using Xbim.Common;
+using Xbim.Common.Exceptions;
+using Xbim.Common.Model;
+using Xbim.Ifc2x3;
+using Xbim.IO.Memory;
+
+namespace Xbim.Essentials.Tests
+{
+    [TestClass]
+    public class ReadSeekableStreamTests
+    {
+        [TestMethod]
+        public void CanOpenFromNonSeekableStream()
+        {
+            // Tests our NonSeekable fake stream
+            const string ifcPath = @"TestFiles/SmallModelIfc2x3.ifc";
+            using var fileStream = File.Open(ifcPath, FileMode.Open);
+            using var stream = new NonSeekableStream(fileStream);
+            Assert.IsFalse(stream.CanSeek);
+
+            using var model = MemoryModel.OpenReadStep21(stream);
+
+            Assert.AreNotEqual(0, model.Instances.Count);
+            
+
+        }
+
+        [TestMethod]
+        public void MemoryModelThrowsWhenNonSeekableStreamUsed()
+        {
+            // Simulate the user reading the header from the stream, before passing to the parser - without our buffered Stream
+
+            const string ifcPath = @"TestFiles/SmallModelIfc2x3.ifc";
+            using var fileStream = File.Open(ifcPath, FileMode.Open);
+            using var stream = new NonSeekableStream(fileStream);
+            Assert.IsFalse(stream.CanSeek);
+
+            var schema = ModelHelper.GetStepFileSchemaVersion(stream);
+
+            stream.Seek(0, SeekOrigin.Begin);   // Will be ignored.
+
+            var ex = Assert.ThrowsException<XbimParserException>(() =>  MemoryModel.OpenReadStep21(stream));
+
+            ex.Message.Should().StartWith("IFC Schema could not be read from Header");
+
+        }
+
+        [TestMethod]
+        public void CanReseekAndOpenFromNonSeekableStream()
+        {
+
+            const string ifcPath = @"TestFiles/SmallModelIfc2x3.ifc";
+
+            using var fileStream = File.Open(ifcPath, FileMode.Open);
+            using var nonseekableStream = new NonSeekableStream(fileStream);
+            Assert.IsFalse(nonseekableStream.CanSeek);
+            using var stream = new ReadSeekableStream(nonseekableStream, 4096);    // 4KB Buffer
+            Assert.IsTrue(stream.CanSeek);
+            var schema = ModelHelper.GetStepFileSchemaVersion(stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            Assert.AreEqual(0, stream.Position);
+
+            var mm = new MemoryModel(new EntityFactoryIfc2x3());
+
+            using var model = MemoryModel.OpenReadStep21(stream);
+            Assert.AreNotEqual(0, model.Instances.Count);
+        }
+
+        [TestMethod]
+        public void CanDisableBuffer()
+        {
+
+            const string ifcPath = @"TestFiles/SmallModelIfc2x3.ifc";
+
+            using var fileStream = File.Open(ifcPath, FileMode.Open);
+            using var nonseekableStream = new NonSeekableStream(fileStream);
+            using var stream = new ReadSeekableStream(nonseekableStream, 4096);
+            var schema = ModelHelper.GetStepFileSchemaVersion(stream);
+            stream.Seek(0, SeekOrigin.Begin);
+
+            stream.DisableBuffering();  // No future Reads are cached
+
+            var mm = new MemoryModel(new EntityFactoryIfc2x3());
+
+            using var model = MemoryModel.OpenReadStep21(stream);
+            Assert.AreNotEqual(0, model.Instances.Count);
+        }
+
+
+        [TestMethod]
+        public void DisablingBufferPreventsSeek()
+        {
+
+            const string ifcPath = @"TestFiles/SmallModelIfc2x3.ifc";
+
+            using var fileStream = File.Open(ifcPath, FileMode.Open);
+            using var nonseekableStream = new NonSeekableStream(fileStream);
+            using var stream = new ReadSeekableStream(nonseekableStream, 4096);    // 4KB Buffer
+            
+            // Makes the Stream useless
+            stream.DisableBuffering();
+            var schema = ModelHelper.GetStepFileSchemaVersion(stream);
+            var ex = Assert.ThrowsException<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
+
+            ex.Message.Should().Be("Cannot seek when back buffer is disabled");
+        }
+
+    }
+
+    /// <summary>
+    /// Simulates a non-seekable stream such as a NetworkStream 
+    /// </summary>
+    public class NonSeekableStream : Stream
+    {
+        private readonly Stream innerStream;
+
+        public NonSeekableStream(Stream innerStream)
+        {
+            this.innerStream = innerStream;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => 0;
+
+        public override long Position { get => innerStream.Position; set => throw new System.NotImplementedException(); }
+
+        public override void Flush()
+        {
+            innerStream.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return innerStream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return Position;    // i.e. silently ignore Seeking
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Tests/Xbim.Essentials.Tests.csproj
+++ b/Tests/Xbim.Essentials.Tests.csproj
@@ -7,7 +7,6 @@
     <Description>Unit Tests for XBIM.Essentials</Description>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\XbimOpenSourceKeyFile.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Xbim.Common/Model/ReadSeekableStream.cs
+++ b/Xbim.Common/Model/ReadSeekableStream.cs
@@ -1,0 +1,288 @@
+﻿using System;
+using System.IO;
+
+namespace Xbim.Common.Model
+{
+    // Based on https://stackoverflow.com/a/28036366
+    /// <summary>
+    /// A Stream implementation that wraps an underlying non-seekable stream to provide a limited 'back buffer'
+    /// which enables the content to be seekable within the buffer window.
+    /// </summary>
+    /// <remarks>Useful to be able to read a header of a file when an input stream is not seekable - e.g. a NetworkStream</remarks>
+    public class ReadSeekableStream : Stream
+    {
+        private long _underlyingPosition;
+        private readonly byte[] _seekBackBuffer;
+        private int _seekBackBufferCount;
+        private int _seekBackBufferIndex;
+        private readonly Stream _underlyingStream;
+        
+
+        /// <summary>
+        /// Constructs a new <see cref="ReadSeekableStream"/> with the provided inner stream and buffer size
+        /// </summary>
+        /// <param name="underlyingStream"></param>
+        /// <param name="seekBackBufferSize"></param>
+        /// <exception cref="Exception"></exception>
+        public ReadSeekableStream(Stream underlyingStream, int seekBackBufferSize)
+        {
+            if (!underlyingStream.CanRead)
+                throw new Exception($"Provided stream {underlyingStream} is not readable");
+
+            if (underlyingStream.CanSeek)
+                throw new Exception($"Provided stream {underlyingStream} is already Seekable, and will not benefit from this wrapper");
+            if (underlyingStream is null)
+            {
+                throw new ArgumentNullException(nameof(underlyingStream));
+            }
+
+            if (seekBackBufferSize <= 0)
+            {
+                throw new Exception("Buffer size must be a positive");
+            }
+
+            _underlyingStream = underlyingStream;
+            _seekBackBuffer = new byte[seekBackBufferSize];
+            BufferEnabled = true;
+        }
+
+        /// <summary>
+        /// Disables any further back buffering. Once disabled Seeking is no longer possible.
+        /// </summary>
+        /// <remarks>This allows you to eliminate the overhead of the buffering once you know you do not need to Seek any further.</remarks>
+        public void DisableBuffering()
+        {
+            BufferEnabled = false;
+        }
+
+        /// <summary>
+        /// Indicates whether the buffer is active
+        /// </summary>
+        public bool BufferEnabled { get; private set; }
+
+        /// <inheritDoc/>
+        public override bool CanRead { get { return true; } }
+
+        /// <summary>
+        /// Indicates whether the stream supports Seeking. Note: this can change if Buffering is disabled.
+        /// </summary>
+        public override bool CanSeek { get { return BufferEnabled; } }
+
+        /// <inheritDoc/>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int copiedFromBackBufferCount = 0;
+            if (_seekBackBufferIndex < _seekBackBufferCount)
+            {
+                // Read from buffer
+                copiedFromBackBufferCount = Math.Min(count, _seekBackBufferCount - _seekBackBufferIndex);
+                Buffer.BlockCopy(_seekBackBuffer, _seekBackBufferIndex, buffer, offset, copiedFromBackBufferCount);
+                offset += copiedFromBackBufferCount;
+                count -= copiedFromBackBufferCount;
+                _seekBackBufferIndex += copiedFromBackBufferCount;
+            }
+            int bytesReadFromUnderlying = 0;
+            if (count > 0)
+            {
+                // Read from underlying and fill buffer
+                bytesReadFromUnderlying = _underlyingStream.Read(buffer, offset, count);
+                if (BufferEnabled && bytesReadFromUnderlying > 0)
+                {
+                    _underlyingPosition += bytesReadFromUnderlying;
+
+                    var copyToBufferCount = Math.Min(bytesReadFromUnderlying, _seekBackBuffer.Length);
+                    var copyToBufferOffset = Math.Min(_seekBackBufferCount, _seekBackBuffer.Length - copyToBufferCount);
+                    var bufferBytesToMove = Math.Min(_seekBackBufferCount - 1, copyToBufferOffset);
+
+                    if (bufferBytesToMove > 0)
+                        Buffer.BlockCopy(_seekBackBuffer, _seekBackBufferCount - bufferBytesToMove, _seekBackBuffer, 0, bufferBytesToMove);
+                    Buffer.BlockCopy(buffer, offset, _seekBackBuffer, copyToBufferOffset, copyToBufferCount);
+                    _seekBackBufferCount = Math.Min(_seekBackBuffer.Length, _seekBackBufferCount + copyToBufferCount);
+                    _seekBackBufferIndex = _seekBackBufferCount;
+                }
+            }
+            return copiedFromBackBufferCount + bytesReadFromUnderlying;
+        }
+
+        /// <summary>
+        /// Sets the position within the current stream. Note: seeking backward is only possible within the range of the buffer window
+        /// </summary>
+        /// <param name="offset"></param>
+        /// <param name="origin"></param>
+        /// <returns></returns>
+        /// <exception cref="NotSupportedException">Thrown when seeking beyond the beginning of the buffer or past the end of the stream</exception>
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if(!BufferEnabled)
+            {
+                throw new NotSupportedException("Cannot seek when back buffer is disabled");
+            }
+            if (origin == SeekOrigin.End)
+                return SeekFromEnd((int)Math.Max(0, -offset));
+
+            var relativeOffset = origin == SeekOrigin.Current
+                ? offset
+                : offset - Position;
+
+            if (relativeOffset == 0)
+                return Position;
+            else if (relativeOffset > 0)
+                return SeekForward(relativeOffset);
+            else
+                return SeekBackwards(-relativeOffset);
+        }
+
+        private long SeekForward(long origOffset)
+        {
+            long offset = origOffset;
+            var seekBackBufferLength = _seekBackBuffer.Length;
+
+            int backwardSoughtBytes = _seekBackBufferCount - _seekBackBufferIndex;
+            int seekForwardInBackBuffer = (int)Math.Min(offset, backwardSoughtBytes);
+            offset -= seekForwardInBackBuffer;
+            _seekBackBufferIndex += seekForwardInBackBuffer;
+
+            if (offset > 0)
+            {
+                // first completely fill seekBackBuffer to remove special cases from while loop below
+                if (_seekBackBufferCount < seekBackBufferLength)
+                {
+                    var maxRead = seekBackBufferLength - _seekBackBufferCount;
+                    if (offset < maxRead)
+                        maxRead = (int)offset;
+                    var bytesRead = _underlyingStream.Read(_seekBackBuffer, _seekBackBufferCount, maxRead);
+                    _underlyingPosition += bytesRead;
+                    _seekBackBufferCount += bytesRead;
+                    _seekBackBufferIndex = _seekBackBufferCount;
+                    if (bytesRead < maxRead)
+                    {
+                        if (_seekBackBufferCount < offset)
+                            throw new NotSupportedException("Reached end of stream seeking forward " + origOffset + " bytes");
+                        return Position;
+                    }
+                    offset -= bytesRead;
+                }
+
+                // now alternate between filling tempBuffer and seekBackBuffer
+                bool fillTempBuffer = true;
+                var tempBuffer = new byte[seekBackBufferLength];
+                while (offset > 0)
+                {
+                    var maxRead = offset < seekBackBufferLength ? (int)offset : seekBackBufferLength;
+                    var bytesRead = _underlyingStream.Read(fillTempBuffer ? tempBuffer : _seekBackBuffer, 0, maxRead);
+                    _underlyingPosition += bytesRead;
+                    var bytesReadDiff = maxRead - bytesRead;
+                    offset -= bytesRead;
+                    if (bytesReadDiff > 0 /* reached end-of-stream */ || offset == 0)
+                    {
+                        if (fillTempBuffer)
+                        {
+                            if (bytesRead > 0)
+                            {
+                                Buffer.BlockCopy(_seekBackBuffer, bytesRead, _seekBackBuffer, 0, bytesReadDiff);
+                                Buffer.BlockCopy(tempBuffer, 0, _seekBackBuffer, bytesReadDiff, bytesRead);
+                            }
+                        }
+                        else
+                        {
+                            if (bytesRead > 0)
+                                Buffer.BlockCopy(_seekBackBuffer, 0, _seekBackBuffer, bytesReadDiff, bytesRead);
+                            Buffer.BlockCopy(tempBuffer, bytesRead, _seekBackBuffer, 0, bytesReadDiff);
+                        }
+                        if (offset > 0)
+                            throw new NotSupportedException("Reached end of stream seeking forward " + origOffset + " bytes");
+                    }
+                    fillTempBuffer = !fillTempBuffer;
+                }
+            }
+            return Position;
+        }
+
+        private long SeekBackwards(long offset)
+        {
+            var intOffset = (int)offset;
+            if (offset > int.MaxValue || intOffset > _seekBackBufferIndex)
+                throw new NotSupportedException("Cannot currently seek backwards more than " + _seekBackBufferIndex + " bytes");
+            _seekBackBufferIndex -= intOffset;
+            return Position;
+        }
+
+        private long SeekFromEnd(long offset)
+        {
+            var intOffset = (int)offset;
+            var seekBackBufferLength = _seekBackBuffer.Length;
+            if (offset > int.MaxValue || intOffset > seekBackBufferLength)
+                throw new NotSupportedException("Cannot seek backwards from end more than " + seekBackBufferLength + " bytes");
+
+            // first completely fill seekBackBuffer to remove special cases from while loop below
+            if (_seekBackBufferCount < seekBackBufferLength)
+            {
+                var maxRead = seekBackBufferLength - _seekBackBufferCount;
+                var bytesRead = _underlyingStream.Read(_seekBackBuffer, _seekBackBufferCount, maxRead);
+                _underlyingPosition += bytesRead;
+                _seekBackBufferCount += bytesRead;
+                _seekBackBufferIndex = Math.Max(0, _seekBackBufferCount - intOffset);
+                if (bytesRead < maxRead)
+                {
+                    if (_seekBackBufferCount < intOffset)
+                        throw new NotSupportedException("Could not seek backwards from end " + intOffset + " bytes");
+                    return Position;
+                }
+            }
+            else
+            {
+                _seekBackBufferIndex = _seekBackBufferCount;
+            }
+
+            // now alternate between filling tempBuffer and seekBackBuffer
+            bool fillTempBuffer = true;
+            var tempBuffer = new byte[seekBackBufferLength];
+            while (true)
+            {
+                var bytesRead = _underlyingStream.Read(fillTempBuffer ? tempBuffer : _seekBackBuffer, 0, seekBackBufferLength);
+                _underlyingPosition += bytesRead;
+                var bytesReadDiff = seekBackBufferLength - bytesRead;
+                if (bytesReadDiff > 0) // reached end-of-stream
+                {
+                    if (fillTempBuffer)
+                    {
+                        if (bytesRead > 0)
+                        {
+                            Buffer.BlockCopy(_seekBackBuffer, bytesRead, _seekBackBuffer, 0, bytesReadDiff);
+                            Buffer.BlockCopy(tempBuffer, 0, _seekBackBuffer, bytesReadDiff, bytesRead);
+                        }
+                    }
+                    else
+                    {
+                        if (bytesRead > 0)
+                            Buffer.BlockCopy(_seekBackBuffer, 0, _seekBackBuffer, bytesReadDiff, bytesRead);
+                        Buffer.BlockCopy(tempBuffer, bytesRead, _seekBackBuffer, 0, bytesReadDiff);
+                    }
+                    _seekBackBufferIndex -= intOffset;
+                    return Position;
+                }
+                fillTempBuffer = !fillTempBuffer;
+            }
+        }
+
+        public override long Position
+        {
+            get { return _underlyingPosition - (_seekBackBufferCount - _seekBackBufferIndex); }
+            set { Seek(value, SeekOrigin.Begin); }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _underlyingStream.Close();
+            base.Dispose(disposing);
+        }
+
+        public override bool CanTimeout { get { return _underlyingStream.CanTimeout; } }
+        public override bool CanWrite { get { return _underlyingStream.CanWrite; } }
+        public override long Length { get { return _underlyingStream.Length; } }
+        public override void SetLength(long value) { _underlyingStream.SetLength(value); }
+        public override void Write(byte[] buffer, int offset, int count) { _underlyingStream.Write(buffer, offset, count); }
+        public override void Flush() { _underlyingStream.Flush(); }
+    }
+}

--- a/Xbim.Common/Model/StepModel.cs
+++ b/Xbim.Common/Model/StepModel.cs
@@ -502,12 +502,13 @@ namespace Xbim.Common.Model
             };
             try
             {
-                parser.Parse();
+                var success = parser.Parse();
+                
 
                 //fix header with the schema if it was not a part of the data
-                if (Header.FileSchema.Schemas.Count == 0)
+                if (Header.FileSchema.Schemas.Count == 0 && EntityFactory != null)
                 {
-                    foreach (var s in EntityFactory.SchemasIds)
+                    foreach (var s in EntityFactory?.SchemasIds)
                     {
                         Header.FileSchema.Schemas.Add(s);
                     }

--- a/Xbim.IO.MemoryModel/MemoryModel.cs
+++ b/Xbim.IO.MemoryModel/MemoryModel.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using Xbim.Common;
 using Xbim.Common.Configuration;
+using Xbim.Common.Exceptions;
 using Xbim.Common.Model;
 using Xbim.Common.Step21;
 using Xbim.Ifc4.Interfaces;
@@ -376,6 +377,10 @@ namespace Xbim.IO.Memory
             var model = new MemoryModel((IEnumerable<string> schemas) =>
             {
                 var schema = GetStepFileXbimSchemaVersion(schemas);
+                if(schema == XbimSchemaVersion.Unsupported)
+                {
+                    throw new XbimParserException("IFC Schema could not be read from Header");
+                }
                 return GetFactory(schema);
             }, loggerFactory)
             {


### PR DESCRIPTION
Fixed up Parser edge cases in StepModel/MemoryModel identified in testing. (Was getting NRE rather than sensible exception if header could not be parsed)

MemoryModel already handled non-seekable streams - it implements a patter with a EntityFactoryDelegate which enables a single pass parse. EssentModel does not - it takes an EnityFactory as a constructore param, and this is what forces IModelProvider and IfcStore to require the XbimSchemaVersion when opening a model from a stream. Need to review if we fix that.

Fixed this by implementing a buffered stream which we use internally in IfcStore when an input stream is not Seekable. The buffer just needs to be large enough to hold the header, (typically 1-2KB). As an optimisation the buffering is disabled after we have read the header so we're not copying streaming data unnecessarily.

