### PR TITLE
XbimP21Scanner's Entities dictionary supports chunking/partitioning to avoid OOM exceptions

### DIFF
--- a/Tests/ChunkedDictionaryTests.cs
+++ b/Tests/ChunkedDictionaryTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using Xbim.Common.Collections;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Xbim.Essentials.Tests
+{
+    [TestClass]
+    public class ChunkedDictionaryTests
+    {
+        
+        [TestMethod]
+        public void Init_ChunkSizeCanBeTotalSize()
+        {
+            var dictionary = new ChunkedDictionary<int, string>(2, 2);
+            var chunks = dictionary.GetChunkCount();
+            Assert.AreEqual(1, chunks, "Chunk count should be 1 when chunk size equals total size.");
+        }
+        
+        [TestMethod]
+        public void Init_OnlyOneChunkInitializedAtTheBeginning()
+        {
+            var dictionary = new ChunkedDictionary<int, string>(20, 2);
+            var chunks = dictionary.GetChunkCount();
+            Assert.AreEqual(1, chunks, "Only one chunk should be initialized at the beginning.");
+        }
+        
+        [TestMethod]
+        public void Add_SingleItem_ItemExists()
+        {
+            var dictionary = new ChunkedDictionary<int, string>(10);
+            dictionary.Add(1, "One");
+
+            Assert.IsTrue(dictionary.ContainsKey(1), "Key should exist after adding.");
+            Assert.AreEqual("One", dictionary[1], "Value should match the added value.");
+        }
+        
+        [TestMethod]
+        public void Remove_ByKey_ItemRemoved()
+        {
+            var dictionary = new ChunkedDictionary<int, string>(10);
+            dictionary.Add(1, "One");
+            var removed = dictionary.Remove(1);
+
+            Assert.IsTrue(removed, "Item should be removed successfully.");
+            Assert.IsFalse(dictionary.ContainsKey(1), "Key should not exist after removal.");
+        }
+
+        [TestMethod]
+        public void Remove_ByKeyValuePair_ItemRemoved()
+        {
+            var dictionary = new ChunkedDictionary<int, string>(10);
+            dictionary.Add(1, "One");
+            var removed = dictionary.Remove(new KeyValuePair<int, string>(1, "One"));
+
+            Assert.IsTrue(removed, "Item should be removed successfully.");
+            Assert.IsFalse(dictionary.ContainsKey(1), "Key should not exist after removal.");
+        }
+
+        [TestMethod]
+        public void TryGetValue_ExistingItem_ReturnsTrueAndCorrectValue()
+        {
+            var dictionary = new ChunkedDictionary<int, string>(10);
+            dictionary.Add(1, "One");
+
+            string value;
+            var result = dictionary.TryGetValue(1, out value);
+
+            Assert.IsTrue(result, "TryGetValue should return true for existing key.");
+            Assert.AreEqual("One", value, "Value should match the added value.");
+        }
+
+        [TestMethod]
+        public void Add_MultipleItems_ExceedChunkSize_DistributesAcrossChunks()
+        {
+            var chunkSize = 5;
+            var dictionary = new ChunkedDictionary<int, string>(chunkSize);
+            for (int i = 0; i < chunkSize * 2; i++)
+            {
+                dictionary.Add(i, $"Item{i}");
+            }
+
+            Assert.AreEqual(chunkSize * 2, dictionary.Count, "Total items should match items added.");
+            Assert.IsTrue(dictionary.Keys.Max() >= chunkSize, "Keys should be distributed across chunks.");
+        }
+        
+        [TestMethod]
+        public void Add_MultipleItems_WithTotalSize_DistributesAcrossChunks()
+        {
+            var chunkSize = 5;
+            var total = (chunkSize * 2) + 2; // +2 to ensure we need more than 2 chunks
+
+            var dictionary = new ChunkedDictionary<int, string>(total, chunkSize);
+            for (int i = 0; i < total; i++)
+            {
+                dictionary.Add(i, $"Item{i}");
+            }
+
+            Assert.AreEqual(total, dictionary.Count, "Total items should match items added.");
+            Assert.IsTrue(dictionary.GetChunkCount() == 3, "We have 3 chunks.");
+        }
+        
+        [TestMethod]
+        public void Add_MultipleItems_WithTotalSize_GrowsWhenAddingMoreItems()
+        {
+            var chunkSize = 5;
+            var total = (chunkSize * 2) + 2;
+
+            var dictionary = new ChunkedDictionary<int, string>(total, chunkSize);
+            for (int i = 0; i < total; i++)
+            {
+                dictionary.Add(i, $"Item{i}");
+            }
+            
+            dictionary.Add(total, $"Item{total}"); // Add one more item creating a new chunk
+
+            Assert.AreEqual(total + 1, dictionary.Count, "Total items should match items added.");
+            Assert.IsTrue(dictionary.GetChunkCount() == 4, "We have 4 chunks.");
+
+            // Add more items to ensure we can grow further
+            for (int i = 1; i < 6; i++)
+            {
+                dictionary.Add(total+i, $"Item{total+i}");
+            }
+            
+            Assert.AreEqual(total + 6, dictionary.Count, "Total items should match items added.");
+            Assert.IsTrue(dictionary.GetChunkCount() == 5, "We have 5 chunks by now.");
+        }
+        
+        [TestMethod]
+        public void KeysAndValues_AfterMutations_AccuratelyReflected()
+        {
+            var dictionary = new ChunkedDictionary<int, string>(10);
+            dictionary.Add(1, "One");
+            dictionary.Add(2, "Two");
+            dictionary.Remove(1);
+
+            var keys = dictionary.Keys;
+            var values = dictionary.Values;
+
+            Assert.IsTrue(keys.Contains(2) && keys.Count == 1, "Keys collection should accurately reflect current keys.");
+            Assert.IsTrue(values.Contains("Two") && values.Count == 1, "Values collection should accurately reflect current values.");
+        }
+        
+        [TestMethod]
+        public void Enumeration_YieldsAllItemsExactlyOnce()
+        {
+            var testData = new Dictionary<int, string>
+            {
+                { 1, "One" }, { 2, "Two" }, { 3, "Three" },
+                { 4, "Four" }, { 5, "Five" }, { 6, "Six" }
+            };
+            var dictionary = new ChunkedDictionary<int, string>(testData.Count, 3);
+
+            foreach (var kvp in testData)
+            {
+                dictionary.Add(kvp.Key, kvp.Value);
+            }
+
+            var enumeratedItems = new Dictionary<int, string>();
+            foreach (var kvp in dictionary)
+            {
+                // Verify no duplicates during enumeration
+                Assert.IsFalse(enumeratedItems.ContainsKey(kvp.Key), "Duplicate key found during enumeration.");
+                enumeratedItems.Add(kvp.Key, kvp.Value);
+            }
+
+            // Verify all items were enumerated
+            Assert.AreEqual(testData.Count, enumeratedItems.Count, "Not all items were enumerated.");
+            foreach (var kvp in testData)
+            {
+                Assert.IsTrue(enumeratedItems.ContainsKey(kvp.Key) && enumeratedItems[kvp.Key] == kvp.Value,
+                    "Missing or incorrect item in enumeration.");
+            }
+        }
+
+        [TestMethod]
+        public void Add_ItemsExceedSingleChunkCapacity_ItemsDistributedAcrossMultipleChunks()
+        {
+            var chunkSize = 3;
+            var itemCount = chunkSize * 2; // Ensure we need at least two chunks
+            var dictionary = new ChunkedDictionary<int, string>(itemCount, chunkSize);
+
+            for (int i = 0; i < itemCount; i++)
+            {
+                dictionary.Add(i, $"Item{i}");
+            }
+
+            var chunkCount = dictionary.GetChunkCount(); 
+            Assert.IsTrue(chunkCount > 1, "Items should be distributed across more than one chunk.");
+        }
+        
+        [TestMethod]
+        [ExpectedException(typeof(KeyNotFoundException))]
+        public void Indexer_GetMissingKey_ThrowsKeyNotFoundException()
+        {
+            var dictionary = new ChunkedDictionary<int, string>(10);
+            var value = dictionary[999]; // This should throw
+        }
+        
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Add_DuplicateKey_ThrowsArgumentException()
+        {
+            var dictionary = new ChunkedDictionary<int, string>(10);
+            dictionary.Add(1, "One");
+            dictionary.Add(1, "One again"); // This should throw
+        }
+        
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Init_InvalidChunkSize_ThrowsArgumentException()
+        {
+            var dictionary = new ChunkedDictionary<int, string>(10, 11);
+        }
+        
+    }
+}

--- a/Xbim.Common/Collections/ChunkedDictionary.cs
+++ b/Xbim.Common/Collections/ChunkedDictionary.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xbim.Common.Collections
+{
+    public class ChunkedDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private int _currentChunk;
+        private readonly List<Dictionary<TKey, TValue>> _chunks = new List<Dictionary<TKey, TValue>>();
+        private readonly List<int> _chunkSizes;
+        private readonly int _preferredChunkSize;
+
+
+        public ChunkedDictionary(int chunkSize)
+        {
+            if (chunkSize <= 0)
+                throw new ArgumentException("Chunk size must be greater than 0.", nameof(chunkSize));
+
+            _preferredChunkSize = chunkSize;
+
+            //get list of chunk sizes
+            _chunkSizes = new List<int>()
+            {
+                3
+            };
+            _currentChunk = 0;
+            _chunks.Add(new Dictionary<TKey, TValue>(_chunkSizes[_currentChunk]));
+        }
+
+        public ChunkedDictionary(int totalSize, int chunkSize)
+        {
+            if (totalSize <= 0)
+                throw new ArgumentException("Total size must be greater than 0.", nameof(totalSize));
+
+            if (chunkSize <= 0)
+                throw new ArgumentException("Chunk size must be greater than 0.", nameof(chunkSize));
+
+            if (chunkSize > totalSize)
+                throw new ArgumentException("Chunk size must be less than or equal to the total size.",
+                    nameof(chunkSize));
+
+            _preferredChunkSize = chunkSize;
+
+            //get list of actual chunk sizes
+            _chunkSizes = new List<int>();
+            while (totalSize > 0)
+            {
+                if (totalSize >= chunkSize)
+                {
+                    _chunkSizes.Add(chunkSize);
+                    totalSize -= chunkSize;
+                }
+                else
+                {
+                    _chunkSizes.Add(totalSize);
+                    totalSize = 0;
+                }
+            }
+
+            _currentChunk = 0;
+            _chunks.Add(new Dictionary<TKey, TValue>(_chunkSizes[_currentChunk]));
+        }
+
+        public TValue this[TKey key]
+        {
+            get => FindChunkContainingKey(key)[key];
+            set
+            {
+                var chunk = FindChunkContainingKey(key, true);
+                chunk[key] = value;
+            }
+        }
+
+        public ICollection<TKey> Keys => _chunks.SelectMany(chunk => chunk.Keys).ToList();
+
+        public ICollection<TValue> Values => _chunks.SelectMany(chunk => chunk.Values).ToList();
+
+        public int Count => _chunks.Sum(chunk => chunk.Count);
+
+        public bool IsReadOnly => false;
+
+        public void Add(TKey key, TValue value)
+        {
+            var chunk = _chunks[_currentChunk].Count >= _chunkSizes[_currentChunk]
+                ? AddNewChunk()
+                : _chunks[_currentChunk];
+            chunk.Add(key, value);
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        public void Clear()
+        {
+            _chunks.Clear();
+            _currentChunk = 0;
+            _chunks.Add(new Dictionary<TKey, TValue>(_chunkSizes[_currentChunk]));
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return _chunks.Any(chunk => chunk.Contains(item));
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return _chunks.Any(chunk => chunk.ContainsKey(key));
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            foreach (var chunk in _chunks)
+            {
+                foreach (var pair in chunk)
+                {
+                    if (arrayIndex >= array.Length) return;
+                    array[arrayIndex++] = pair;
+                }
+            }
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return _chunks.SelectMany(chunk => chunk).GetEnumerator();
+        }
+
+        public bool Remove(TKey key)
+        {
+            var chunk = FindChunkContainingKey(key);
+            return chunk != null && chunk.Remove(key);
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            var chunk = FindChunkContainingKey(item.Key);
+            return chunk != null && chunk.Remove(item.Key);
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            var chunk = FindChunkContainingKey(key);
+            if (chunk != null)
+                return chunk.TryGetValue(key, out value);
+
+            value = default;
+            return false;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        private Dictionary<TKey, TValue> FindChunkContainingKey(TKey key, bool createIfNotExists = false)
+        {
+            foreach (var chunk in _chunks)
+            {
+                if (chunk.ContainsKey(key))
+                    return chunk;
+            }
+
+            if (createIfNotExists)
+                return AddNewChunk();
+
+            throw new KeyNotFoundException($"The given key was not present in the dictionary.");
+        }
+
+        private Dictionary<TKey, TValue> AddNewChunk()
+        {
+            _currentChunk++;
+            if (_chunkSizes.Count <= _currentChunk)
+            {
+                // grow the chunk sizes list with a chunk size equal to the preferred chunk size
+                _chunkSizes.Add(_preferredChunkSize);
+            }
+
+            var newChunk = new Dictionary<TKey, TValue>(_chunkSizes[_currentChunk]);
+            _chunks.Add(newChunk);
+            return newChunk;
+        }
+
+        internal int GetChunkCount()
+        {
+            return _chunks.Count;
+        }
+    }
+}

--- a/Xbim.Common/Step21/XbimP21Scanner.cs
+++ b/Xbim.Common/Step21/XbimP21Scanner.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xbim.Common;
+using Xbim.Common.Collections;
 using Xbim.Common.Exceptions;
 using Xbim.Common.Configuration;
 using Xbim.Common.Metadata;
@@ -111,11 +112,12 @@ namespace Xbim.IO.Step21
                 if (adjustRatio < 0) adjustRatio = 0;
                 entityApproxCount = (int)( entityApproxCount * adjustRatio);
             }
-
             // make it 4 at least
             if (entityApproxCount < 1) entityApproxCount = 4;
-
-            Entities = new Dictionary<int, IPersist>(entityApproxCount);
+            var chunkSize = 100_000_000;
+            Entities = entityApproxCount > chunkSize?
+                new ChunkedDictionary<int, IPersist>(entityApproxCount, chunkSize) :
+                new Dictionary<int, IPersist>(entityApproxCount);
             _deferredReferences = new List<DeferredReference>(entityApproxCount / 4); //assume 50% deferred
         }
 
@@ -716,7 +718,7 @@ namespace Xbim.IO.Step21
             }
         }
 
-        public Dictionary<int, IPersist> Entities { get; private set; }
+        public IDictionary<int, IPersist> Entities { get; private set; }
 
         internal bool TrySetObjectValue(IPersist host, int paramIndex, int refId, int[] listNextLevel)
         {


### PR DESCRIPTION
This PR introducing a chunking/partitioning  mechanism for under the hood for the Entities dictionary of the XbimP21Scanner to avoid OutOfMemory exceptions that may arise out of big approximate calculated dictionary capacity.