### PR TITLE
Fix for #595 - SelectMany would return incomplete results in certain circumstances

### DIFF
--- a/Xbim.Common/Collections/ProxyItemSet.cs
+++ b/Xbim.Common/Collections/ProxyItemSet.cs
@@ -98,10 +98,7 @@ namespace Xbim.Common.Collections
 
         public void CopyTo(TOuter[] array, int arrayIndex)
         {
-            var result = new TInner[array.Length];
-            _inner.CopyTo(result, arrayIndex);
-            for (var i = 0; i < array.Length; i++)
-                array[i] = result[i];
+            _inner.ToArray().CopyTo(array, arrayIndex);
         }
 
         public bool Remove(TOuter item)

--- a/Xbim.Essentials.NetCore.Tests/Collections/ProxyItemSetTests.cs
+++ b/Xbim.Essentials.NetCore.Tests/Collections/ProxyItemSetTests.cs
@@ -1,0 +1,66 @@
+﻿using FluentAssertions;
+using System;
+using System.Linq;
+using Xbim.Common;
+using Xbim.Common.Collections;
+using Xbim.Ifc4;
+using Xbim.Ifc4.Interfaces;
+using Xbim.Ifc4.MaterialResource;
+using Xbim.Ifc4.SharedBldgElements;
+using Xbim.IO.Memory;
+using Xunit;
+
+namespace Xbim.Essentials.NetCore.Tests.Collections
+{
+    public class ProxyItemSetTests
+    {
+        [Fact]
+        public void CanCopyToGenericArray()
+        {
+            using var model = new MemoryModel(new EntityFactoryIfc4());
+
+            ProxyItemSet<IfcMaterial, IIfcMaterial> set1 = BuildSet(model, 2);
+            ProxyItemSet<IfcMaterial, IIfcMaterial> set2 = BuildSet(model, 3,2);
+
+            IIfcMaterial[] array = new IIfcMaterial[5];
+            set1.CopyTo(array, 0);
+            set2.CopyTo(array, set1.Count());
+
+            array.Should().NotContainNulls();
+
+            int i = 0;
+            do
+            {
+                array[i].Name.ToString().Should().EndWith($"{i}");
+                i++;
+            } while (i < array.Length);
+
+        }
+
+        private static ProxyItemSet<IfcMaterial, IIfcMaterial> BuildSet(MemoryModel model, int count, int start = 0)
+        {
+            TestItemSet<IfcMaterial> collection = null;
+            using (var tx = model.BeginTransaction("memory"))
+            {
+                var parent = model.Instances.New<IfcWall>(m => m.Name = $"Parent");
+                collection = new TestItemSet<IfcMaterial>(parent, count, 0);
+                for (int i = 0; i < count; i++)
+                {
+                    var item = model.Instances.New<IfcMaterial>(m => m.Name = $"Item {start + i}");
+                    collection.Add(item);
+                }
+
+                tx.Commit();
+            }
+           
+            var set1 = new ProxyItemSet<IfcMaterial, IIfcMaterial>(collection);
+            return set1;
+        }
+    }
+
+    internal class TestItemSet<T> : Xbim.Common.Collections.ItemSet<T>
+    {
+        public TestItemSet(IPersistEntity parent, int capacity, int property) :  base(parent, capacity, property)
+        { }
+    }
+}

--- a/Xbim.Essentials.NetCore.Tests/DependencyInjectionTests.cs
+++ b/Xbim.Essentials.NetCore.Tests/DependencyInjectionTests.cs
@@ -1,15 +1,15 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Xbim.Common.Configuration;
+using Xunit;
 
 
 namespace Xbim.Essentials.NetCore.Tests
 {
-    [TestClass]
+    
     public class DependencyInjectionTests
     {
 
-        [TestMethod]
+        [Fact]
         public void ServiceProviderIsValid()
         {
 

--- a/Xbim.Essentials.NetCore.Tests/EsentTests.cs
+++ b/Xbim.Essentials.NetCore.Tests/EsentTests.cs
@@ -1,20 +1,17 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using FluentAssertions;
 using Xbim.Ifc4;
+using Xunit;
 
 namespace Xbim.Essentials.NetCore.Tests
 {
-    [TestClass]
     public class EsentTests
     {
-        [TestMethod]
+        [Fact]
         public void CanCreateEsentModel()
         {
             var esentModel = new Xbim.IO.Esent.EsentModel(new EntityFactoryIfc4());
 
-            Assert.IsNotNull(esentModel);
+            esentModel.Should().NotBeNull();
         }
     }
 }

--- a/Xbim.Essentials.NetCore.Tests/GithubTests.cs
+++ b/Xbim.Essentials.NetCore.Tests/GithubTests.cs
@@ -1,0 +1,101 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xbim.Ifc4;
+using Xbim.Ifc4.Interfaces;
+using Xbim.Ifc4.MaterialResource;
+using Xbim.Ifc4.MeasureResource;
+using Xbim.Ifc4.PropertyResource;
+using Xbim.IO.Memory;
+using Xunit;
+
+namespace Xbim.Essentials.NetCore.Tests
+{
+   
+    public class GithubTests
+    {
+
+        [Fact]
+        public void GithubIssue_595_Fails_With_LinqSelectMany()
+        {
+            // In .net core only, a SelectMany<TSource, TResult> projection could produce a result containing null values when none were null
+            // in the TSource set. Only the last projected Items would remain in the TResults collection. When calling ToArray/ToList.
+            // This was because when using Ifc4 (cross-schema) interfaces, and projecting and casting (to the IIfcProperty interface) in
+            // Netcore SelectMany<T1,T2> this invokes List<T1>.AddRange which in turn called
+            // xbim's ProxyItemsSet.CopyTo(T[] targetArray, int offset) which was incorrectly implemented
+
+
+            using var model = new MemoryModel(new EntityFactoryIfc4());
+
+            InitialiseIfc4Model(model);
+
+            // The issues below disappear when using IfcMaterial directly here
+            var imaterial = model.Instances.OfType<IIfcMaterial>().First();
+
+
+            // ACT
+
+            
+            List<IIfcProperty> flattenedProperties = imaterial.HasProperties.SelectMany(a => a.Properties).ToList();
+
+            // Assert
+
+            flattenedProperties.Should().HaveCount(2);
+
+            flattenedProperties.Should().NotContainNulls();
+        }
+
+     
+        private static void InitialiseIfc4Model(MemoryModel model)
+        {
+            using (var tx = model.BeginTransaction("memory"))
+            {
+                var material = model.Instances.New<IfcMaterial>(m => m.Name = "TestMaterial");
+
+                model.Instances.New<IfcMaterialProperties>(ps =>
+                {
+                    ps.Name = "A";
+                    ps.Material = material;
+                    ps.Properties.Add(
+                        model.Instances.New<IfcPropertySingleValue>(pv =>
+                        {
+                            pv.Name = "A1";
+                            pv.NominalValue = new IfcMolecularWeightMeasure(1);
+                        })
+                    );
+                });
+
+                model.Instances.New<IfcMaterialProperties>(ps =>
+                {
+                    ps.Name = "B";
+                    ps.Material = material;
+                    ps.Properties.Add(
+                        model.Instances.New<IfcPropertySingleValue>(pv =>
+                        {
+                            pv.Name = "B1";
+                            pv.NominalValue = new IfcThermalConductivityMeasure(2);
+                        })
+                    );
+                });
+
+                tx.Commit();
+            }
+        }
+    }
+
+    public static class Enumerable2
+    {
+        public static IEnumerable<TResult> SelectMany<TSource, TResult>(IEnumerable<TSource> source, Func<TSource, IEnumerable<TResult>> selector)
+        {
+            foreach (TSource item in source)
+            {
+                foreach (TResult item2 in selector(item))
+                {
+                    yield return item2;
+                }
+            }
+        }
+    }
+
+}

--- a/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
+++ b/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
@@ -9,10 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Xbim.Essentials.NetCore.Tests/XmlSerializationTests.cs
+++ b/Xbim.Essentials.NetCore.Tests/XmlSerializationTests.cs
@@ -1,16 +1,16 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Xml;
 using Xbim.Ifc4;
 using Xbim.Ifc4.ActorResource;
 using Xbim.IO.Memory;
+using Xunit;
 
 namespace Xbim.Essentials.NetCore.Tests
 {
-    [TestClass]
+
     public class XmlSerializationTests
     {
-        [TestMethod]
+        [Fact]
         public void SerializeXML()
         {
             using (var model = new MemoryModel(new EntityFactoryIfc4()))


### PR DESCRIPTION
In netcore, Linq's SelectMany has an optimised [iterator](https://github.com/dotnet/runtime/blob/843f7985e470f5526799abacb81cbb245c7dec70/src/libraries/System.Linq/src/System/Linq/SelectMany.SpeedOpt.cs#L40) which when forcing enumeration via ToList/ToArray would trigger a [ICollection.CopyTo()](https://github.com/dotnet/runtime/blob/843f7985e470f5526799abacb81cbb245c7dec70/src/libraries/System.Linq/src/System/Linq/SegmentedArrayBuilder.cs#L184) - and `CopyTo(T[])` was incorrectly implemented in our ProxyItemSet.

This is seemingly only triggered in netcore (net6/net8) when projecting with IFC4 interfaces.

Hypothesis is that net framework's SelectMany does not have the Span/allocation optimisations introduced in netcore, that maybe mean a different implementation during the SelectMany projection. Hence this long-standing bug was never hit.

Todo:

* [ ] review this when we revisit Span optimisations. E.g. Does List.ToArray() cause allocations and can we avoid them?