### PR TITLE
Fixed issue where IfcMonetaryUnit.FullName failed under .net8

### DIFF
--- a/Tests/Ifc4x3ExtensionsTests.cs
+++ b/Tests/Ifc4x3ExtensionsTests.cs
@@ -285,6 +285,7 @@ namespace Xbim.Essentials.Tests
                 u.Currency = tla;
             });
 
+            currency.FullName.Should().Be(expectedName);
             currency.Symbol().Should().Be(expectedSymbol);
             currency.FullEnglishName().Should().Be(expectedName);
             currency.FullNativeName().Should().Be(nativeName);

--- a/Tests/MonetaryUnitTests.cs
+++ b/Tests/MonetaryUnitTests.cs
@@ -1,0 +1,81 @@
+﻿using FluentAssertions;
+using Xbim.Ifc;
+using Xbim.Ifc4.Interfaces;
+using Xbim.IO.Memory;
+using Xunit;
+
+namespace Xbim.Essentials.Tests
+{
+    public class MonetaryUnitTests
+    {
+ 
+        [InlineData("USD", "$", "US Dollar")]
+        [InlineData("GBP", "£", "British Pound", "Pound Sterling")]
+        [InlineData("EUR", "€", "Euro", "euro")]    // 'euro' since French culture picked up by default
+        [InlineData("CAD", "$", "Canadian Dollar")]
+        [InlineData("AUD", "$", "Australian Dollar")]
+        [InlineData("PLN", "zł", "Polish Zloty", "złoty polski")]
+        [Theory]
+        public void CanReadMonetaryUnit4x3(string tla, string expectedSymbol, string expectedName, string nativeName = null)
+        {
+            using var model = new MemoryModel(new Ifc4x3.EntityFactoryIfc4x3Add2());
+            using var txn = model.BeginTransaction("Test");
+
+            nativeName = nativeName ?? expectedName;
+            var currency = model.Instances.New<Ifc4x3.MeasureResource.IfcMonetaryUnit>(u =>
+            {
+                u.Currency = tla;
+            });
+
+            currency.FullName.Should().Be(expectedName);
+            currency.Symbol().Should().Be(expectedSymbol);
+            currency.FullEnglishName().Should().Be(expectedName);
+            currency.FullNativeName().Should().Be(nativeName);
+        }
+
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.USD, "$", "US Dollar")]
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.GBP, "£", "British Pound", "Pound Sterling")]
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.EUR, "€", "Euro", "euro")]    // 'euro' since French culture picked up by default
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.CAD, "$", "Canadian Dollar")]
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.AUD, "$", "Australian Dollar")]
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.PLN, "zł", "Polish Zloty", "złoty polski")]
+        [Theory]
+        public void CanReadMonetaryUnit2x3(Ifc2x3.MeasureResource.IfcCurrencyEnum tla, string expectedSymbol, string expectedName, string nativeName = null)
+        {
+            using var model = new MemoryModel(new Ifc2x3.EntityFactoryIfc2x3());
+            using var txn = model.BeginTransaction("Test");
+            nativeName = nativeName ?? expectedName;
+            IIfcMonetaryUnit currency = model.Instances.New<Ifc2x3.MeasureResource.IfcMonetaryUnit>(u =>
+            {
+                u.Currency = tla;
+            });
+
+            currency.FullName.Should().Be(expectedName);
+            currency.Symbol().Should().Be(expectedSymbol);
+            currency.FullEnglishName().Should().Be(expectedName);
+            currency.FullNativeName().Should().Be(nativeName);
+        }
+
+        [InlineData("US DOLLAR")]
+        [InlineData("BAD")]
+        [InlineData("BA")]
+        [InlineData("")]
+        //[InlineData(null)]
+        [Theory]
+        public void InvalidMonetaryUnitHandled(string invalidUnit)
+        {
+            using var model = new MemoryModel(new Ifc4.EntityFactoryIfc4());
+            using var txn = model.BeginTransaction("Test");
+     
+            IIfcMonetaryUnit currency = model.Instances.New<Ifc4.MeasureResource.IfcMonetaryUnit>(u =>
+            {
+                u.Currency = invalidUnit;
+            });
+
+            currency.FullName.Should().Be(invalidUnit);
+            currency.Symbol().Should().Be(invalidUnit);
+            currency.FullEnglishName().Should().Be(invalidUnit);
+            currency.FullNativeName().Should().Be(invalidUnit);
+        }
+    }
+}

--- a/Xbim.Essentials.NetCore.Tests/CultureTests.cs
+++ b/Xbim.Essentials.NetCore.Tests/CultureTests.cs
@@ -1,0 +1,39 @@
+﻿using FluentAssertions;
+using Xbim.Ifc;
+using Xbim.Ifc4.Interfaces;
+using Xbim.IO.Memory;
+using Xunit;
+
+
+namespace Xbim.Essentials.NetCore.Tests
+{
+    public class CultureTests
+    {
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.USD, "$", "US Dollar")]
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.GBP, "£", "British Pound", "British Pound")] // en-GB Native name is different in net core to netfx (Pounds Sterling)
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.EUR, "€", "Euro", "euro")]    // 'euro' since French culture picked up by default
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.CAD, "$", "Canadian Dollar")]
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.AUD, "$", "Australian Dollar")]
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.PLN, "zł", "Polish Zloty", "złoty polski")]
+        [Theory]
+        public void CanReadMonetaryUnit2x3(Ifc2x3.MeasureResource.IfcCurrencyEnum tla, string expectedSymbol, string expectedName, string nativeName = null)
+        {
+
+            using var model = new MemoryModel(new Ifc2x3.EntityFactoryIfc2x3());
+            using var txn = model.BeginTransaction("Test");
+            nativeName = nativeName ?? expectedName;
+            IIfcMonetaryUnit currency = model.Instances.New<Ifc2x3.MeasureResource.IfcMonetaryUnit>(u =>
+            {
+                u.Currency = tla;
+            });
+
+            currency.FullName.Should().Be(expectedName);
+            currency.Symbol().Should().Be(expectedSymbol);
+            currency.FullEnglishName().Should().Be(expectedName);
+            currency.FullNativeName().Should().Be(nativeName);
+        }
+
+    }
+
+    
+}

--- a/Xbim.Ifc2x3/MeasureResource/IfcMonetaryUnitPartial.cs
+++ b/Xbim.Ifc2x3/MeasureResource/IfcMonetaryUnitPartial.cs
@@ -17,7 +17,7 @@ namespace Xbim.Ifc2x3.MeasureResource
         }
 
         /// <summary>
-        /// ets the name of the currency as its known internationally
+        /// Gets the name of the currency as its known internationally
         /// </summary>
         /// <returns>String as full name</returns>
         public string FullEnglishName

--- a/Xbim.Ifc4x3/Interfaces/IFC4/IfcMonetaryUnit.cs
+++ b/Xbim.Ifc4x3/Interfaces/IFC4/IfcMonetaryUnit.cs
@@ -11,6 +11,7 @@ using Xbim.Ifc4.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
 using Xbim.Common;
+using Xbim.Ifc4.MeasureResource;
 
 //## Custom using statements
 //##
@@ -35,7 +36,7 @@ namespace Xbim.Ifc4x3.MeasureResource
 			}
 		}
 	//## Custom code
-		public string FullName => Currency;
+		public string FullName => this.FullEnglishName();
 	//##
 	}
 }


### PR DESCRIPTION
net core has different culture packs to net framework Improved the culture lookup approach to be more stable across different environments