### PR TITLE
Fix issue in latest ExpressMetaData where IFC4 and 4X3 types could get duplicated

### DIFF
--- a/Tests/ExpressMetadataTests.cs
+++ b/Tests/ExpressMetadataTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using System;
+using System.Linq;
 using System.Reflection;
 using Xbim.Common;
 using Xbim.Common.Metadata;
@@ -11,9 +12,9 @@ namespace Xbim.Essentials.Tests
     {
         [InlineData(typeof(Xbim.Common.PersistEntity), 0)]  // Nothing defined in this schema
         [InlineData(typeof(Xbim.Ifc2x3.EntityFactoryIfc2x3), 771)]
-        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4), 933)]
-        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4x1), 933)]
-        [InlineData(typeof(Xbim.Ifc4x3.EntityFactoryIfc4x3Add2), 1008)]
+        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4), 932)]
+        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4x1), 932)]
+        [InlineData(typeof(Xbim.Ifc4x3.EntityFactoryIfc4x3Add2), 1007)]
         [Theory]
         [Obsolete]
         public void HasExpectedSchemaTypesByModule(Type moduleType, int expectedTypes)
@@ -21,12 +22,14 @@ namespace Xbim.Essentials.Tests
 
             var m = moduleType.GetTypeInfo().Module;
             var metaData = ExpressMetaData.GetMetadata(moduleType.Module);
-            metaData.Types().Should().HaveCount(expectedTypes);
+            metaData.Types()
+                .Where(t => t.Name != "IfcStrippedOptional")
+                .Should().HaveCount(expectedTypes);
         }
 
         [InlineData(typeof(Xbim.Ifc2x3.EntityFactoryIfc2x3), 771)]
-        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4), 933)]
-        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4x1), 933)]
+        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4), 932)]
+        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4x1), 932)]
         [InlineData(typeof(Xbim.Ifc4x3.EntityFactoryIfc4x3Add2), 1008)]
         [Theory]
         public void HasExpectedSchemaTypesByFactory(Type moduleType, int expectedTypes)
@@ -36,6 +39,28 @@ namespace Xbim.Essentials.Tests
             factory.Should().NotBeNull();
             var metaData = ExpressMetaData.GetMetadata(factory);
             metaData.Types().Should().HaveCount(expectedTypes);
+        }
+
+
+        [InlineData(typeof(Xbim.Ifc2x3.EntityFactoryIfc2x3))]
+        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4))]
+        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4x1))]
+        [InlineData(typeof(Xbim.Ifc4x3.EntityFactoryIfc4x3Add2))]
+        [Theory]
+        [Obsolete]
+        public void HasSameAcrossMethods(Type moduleType)
+        {
+            var module = moduleType.GetTypeInfo().Module;
+            var factory = Activator.CreateInstance(moduleType) as IEntityFactory;
+
+            var originalMeta = ExpressMetaData.GetMetadata(module);
+            var metaData = ExpressMetaData.GetMetadata(factory);
+
+            foreach (var type in originalMeta.Types().Where(t => t.Name != "IfcStrippedOptional"))
+            {
+                metaData.Types().Select(t => t.Name).Should().Contain(type.Name);
+            }
+
         }
 
         [Fact]

--- a/Tests/ParsingTests.cs
+++ b/Tests/ParsingTests.cs
@@ -537,7 +537,20 @@ namespace Xbim.Essentials.Tests
                 }
                 store.SaveAs("esent4.ifc");
                 store.Close();
+
             }
+            using (var store = IfcStore.Create(credentials, XbimSchemaVersion.Ifc4x3, XbimStoreType.EsentDatabase))
+            {
+                using (var txn = store.BeginTransaction())
+                {
+                    var door = store.Instances.New<Ifc4x3.SharedBldgElements.IfcDoor>();
+                    door.Name = "Door 1";
+                    txn.Commit();
+                }
+                store.SaveAs("esent4x3.ifc");
+                store.Close();
+            }
+
 
             using (var store = IfcStore.Create(credentials, XbimSchemaVersion.Ifc2X3, XbimStoreType.InMemoryModel))
             {
@@ -563,15 +576,32 @@ namespace Xbim.Essentials.Tests
                 store.Close();
             }
 
+            using (var store = IfcStore.Create(credentials, XbimSchemaVersion.Ifc4x3, XbimStoreType.InMemoryModel))
+            {
+                using (var txn = store.BeginTransaction())
+                {
+                    var door = store.Instances.New<Ifc4x3.SharedBldgElements.IfcDoor>();
+                    door.Name = "Door 1";
+                    txn.Commit();
+                }
+                store.SaveAs("Memory4x3.ifc");
+                store.Close();
+            }
+
             var modelStore = new HeuristicModelProvider();
             var schemaVersion = modelStore.GetXbimSchemaVersion("Esent2X3.ifc");
             Assert.IsTrue(schemaVersion == XbimSchemaVersion.Ifc2X3);
             schemaVersion = modelStore.GetXbimSchemaVersion("Esent4.ifc");
             Assert.IsTrue(schemaVersion == XbimSchemaVersion.Ifc4);
+            schemaVersion = modelStore.GetXbimSchemaVersion("Esent4x3.ifc");
+            Assert.IsTrue(schemaVersion == XbimSchemaVersion.Ifc4x3);
+
             schemaVersion = modelStore.GetXbimSchemaVersion("Memory2X3.ifc");
             Assert.IsTrue(schemaVersion == XbimSchemaVersion.Ifc2X3);
             schemaVersion = modelStore.GetXbimSchemaVersion("Memory4.ifc");
             Assert.IsTrue(schemaVersion == XbimSchemaVersion.Ifc4);
+            schemaVersion = modelStore.GetXbimSchemaVersion("Memory4x3.ifc");
+            Assert.IsTrue(schemaVersion == XbimSchemaVersion.Ifc4x3);
         }
 
 

--- a/Xbim.Common/Metadata/ExpressMetaData.cs
+++ b/Xbim.Common/Metadata/ExpressMetaData.cs
@@ -113,7 +113,7 @@ namespace Xbim.Common.Metadata
         private ExpressMetaData(IEntityFactory factory)
         {
             Module = factory.GetType().Module;
-            var schemaNamespace = factory.GetType().Namespace;
+            var schemaNamespace = factory.GetType().Namespace + ".";
             var typesToProcess =
                 Module.GetTypes().Where(
                     t => IsExpressTypeForSchema(t, schemaNamespace)).ToList();


### PR DESCRIPTION
Only when schemas share an assembly (ILRepack etc). 