### PR TITLE
PR for Issue #616 - Cast building elevation to allow ordering by elevation when returning storeys

### DIFF
--- a/Xbim.Ifc4x3/Interfaces/IFC4/IfcBuilding.cs
+++ b/Xbim.Ifc4x3/Interfaces/IFC4/IfcBuilding.cs
@@ -117,7 +117,7 @@ namespace Xbim.Ifc4x3.ProductExtension
 			get
 			{
 				return IsDecomposedBy.SelectMany(s => s.RelatedObjects).OfType<IIfcBuildingStorey>()
-					.OrderBy(s => s.Elevation.HasValue ? s.Elevation.Value : 0f);
+					.OrderBy(s => s.Elevation.HasValue ? (double)s.Elevation.Value : 0f);
 			}
 		}
 		//##


### PR DESCRIPTION
Cast Elevation value from object to double to make it IComparable to be used by the OrderBy()

Reference:  [Issue #616](https://github.com/xBimTeam/XbimEssentials/issues/616)
