### PR TITLE
Implement fluent style helpers and interfaces to simplify IFC creation

### DIFF
--- a/Tests/CommonTests.cs
+++ b/Tests/CommonTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -54,8 +55,10 @@ namespace Xbim.Essentials.Tests
         {
             var model = new StepModel(new Ifc4.EntityFactoryIfc4());
             var header = new StepFileHeader(StepFileHeader.HeaderCreationMode.InitWithXbimDefaults, model);
-            Assert.IsTrue(header.FileName.OriginatingSystem == model.GetType().GetTypeInfo().Assembly.GetName().Name);
-            Assert.IsTrue(header.FileName.PreprocessorVersion == string.Format("Processor version {0}", model.GetType().GetTypeInfo().Assembly.GetName().Version));
+            header.FileName.OriginatingSystem.Should().StartWith("Xbim.Common");
+            var versInfo = new XbimAssemblyInfo(model.GetType().GetTypeInfo().Assembly);
+            var expectedPreProcessor = string.Format("xbim Toolkit v{0}", versInfo.FileVersion);
+            header.FileName.PreprocessorVersion.Should().Be(expectedPreProcessor);
         }
 
         [TestMethod]

--- a/Xbim.Common/Step21/IStepFileDescription.cs
+++ b/Xbim.Common/Step21/IStepFileDescription.cs
@@ -4,12 +4,33 @@ using System.IO;
 
 namespace Xbim.Common.Step21
 {
+    /// <summary>
+    /// Represents the STEP FILE_DESCRIPTION entity which provides version information about the IFC file
+    /// </summary>
     public interface IStepFileDescription : IPersist, IExpressHeaderType, INotifyPropertyChanged
     {
+        /// <summary>
+        /// The formal definition of the underlying view definition(s). e.g 'ViewDefinition [CoordinationView]',
+        /// or Options/Comments provided by the IFC authoring system.
+        /// </summary>
         IList<string> Description {get;set;}
+        /// <summary>
+        /// The STEP Implementation level. This should always be '2;1' for IFC files
+        /// </summary>
         string ImplementationLevel { get; set; }
+        /// <summary>
+        /// The number of entities in this model
+        /// </summary>
         int EntityCount { get; set; }
+        /// <summary>
+        /// Writes the FILE_DESCRIPTION entity to a STEP IFC File
+        /// </summary>
+        /// <param name="binaryWriter"></param>
         void Write(BinaryWriter binaryWriter);
+        /// <summary>
+        /// Reads the FILE_DESCRIPTION entity from a STEP IFC File
+        /// </summary>
+        /// <param name="binaryReader"></param>
         void Read(BinaryReader binaryReader);
     }
 }

--- a/Xbim.Common/Step21/IStepFileName.cs
+++ b/Xbim.Common/Step21/IStepFileName.cs
@@ -4,17 +4,57 @@ using System.IO;
 
 namespace Xbim.Common.Step21
 {
+    /// <summary>
+    /// Represents the STEP FILE_NAME entity which provides human readable information about the IFC
+    /// </summary>
     public interface IStepFileName : IPersist, IExpressHeaderType, INotifyPropertyChanged
     {
-        string Name{get;set;}
+        /// <summary>
+        /// The local path and file name of the IFC file
+        /// </summary>
+        string Name {get;set;}
+        /// <summary>
+        /// The time of creation on the IFC file in ISO 8601 format
+        /// </summary>
         string TimeStamp { get; set; }
+        /// <summary>
+        /// The name and mailing address of the person responsible for creating the IFC.
+        /// </summary>
+        /// <remarks>E.g. login or email address of the user</remarks>
         IList<string> AuthorName{ get; set; }
+        /// <summary>
+        /// The group or organization with whom the author is associated.
+        /// </summary>
         IList<string> Organization { get; set; }
+        /// <summary>
+        /// Name and version of the toolbox used to create the IFC file, 
+        /// </summary>
+        /// <remarks>NOT the name of the application itself.</remarks>
         string PreprocessorVersion { get; set; }
+        /// <summary>
+        /// Name and version and/or build number of the application which generates the IFC file
+        /// </summary>
+        /// <remarks>This is the name of the application. Note: The version and/or build number should be as 
+        /// specific as possible.
+        /// </remarks>
         string OriginatingSystem { get; set; }
+        /// <summary>
+        /// The name and mailing address of the person who authorized the sending of the IFC File
+        /// </summary>
         string AuthorizationName { get; set; }
+        /// <summary>
+        /// The name and mailing address of the person who authorized the sending of the IFC File
+        /// </summary>
         IList<string> AuthorizationMailingAddress { get; set; }
+        /// <summary>
+        /// Writes the FILE_NAME entity to a STEP IFC File
+        /// </summary>
+        /// <param name="binaryWriter"></param>
         void Write(BinaryWriter binaryWriter);
+        /// <summary>
+        /// Reads the FILE_NAME entity from a STEP IFC File
+        /// </summary>
+        /// <param name="binaryReader"></param>
         void Read(BinaryReader binaryReader);
     }
 }

--- a/Xbim.Common/Step21/IStepFileSchema.cs
+++ b/Xbim.Common/Step21/IStepFileSchema.cs
@@ -4,10 +4,24 @@ using System.IO;
 
 namespace Xbim.Common.Step21
 {
+    /// <summary>
+    /// Represents the STEP FILE_SCHEMA entity which identifies the EXPRESS schema information for the IFC file
+    /// </summary>
     public interface IStepFileSchema : IPersist, IExpressHeaderType, INotifyPropertyChanged
     {
+        /// <summary>
+        /// The name of the IFC Schema the IFC file adheres to
+        /// </summary>
         IList<string> Schemas { get; set; }
+        /// <summary>
+        /// Writes the FILE_SCHEMA entity to a STEP IFC File
+        /// </summary>
+        /// <param name="binaryWriter"></param>
         void Write(BinaryWriter binaryWriter);
+        /// <summary>
+        /// Reads the FILE_SCHEMA entity from a STEP IFC File
+        /// </summary>
+        /// <param name="binaryReader"></param>
         void Read(BinaryReader binaryReader);
     }
 }

--- a/Xbim.Common/Step21/StepFileHeader.cs
+++ b/Xbim.Common/Step21/StepFileHeader.cs
@@ -111,6 +111,8 @@ namespace Xbim.Common.Step21
             _implementationLevel = binaryReader.ReadString();
         }
 
+
+        //<inheritDoc/>
         public IList<string> Description
         {
             get
@@ -126,6 +128,7 @@ namespace Xbim.Common.Step21
             }
         }
 
+        //<inheritDoc/>
         public string ImplementationLevel
         {
             get
@@ -139,6 +142,7 @@ namespace Xbim.Common.Step21
             }
         }
 
+        //<inheritDoc/>
         public int EntityCount
         {
             get { return _entityCount; }
@@ -292,6 +296,7 @@ namespace Xbim.Common.Step21
             }
         }
 
+        //<inheritDoc/>
         public string Name
         {
             get
@@ -305,6 +310,7 @@ namespace Xbim.Common.Step21
             }
         }
 
+        //<inheritDoc/>
         public string TimeStamp
         {
             get
@@ -318,6 +324,7 @@ namespace Xbim.Common.Step21
             }
         }
 
+        //<inheritDoc/>
         public IList<string> AuthorName
         {
             get
@@ -333,6 +340,7 @@ namespace Xbim.Common.Step21
             }
         }
 
+        //<inheritDoc/>
         public IList<string> Organization
         {
             get
@@ -348,6 +356,7 @@ namespace Xbim.Common.Step21
             }
         }
 
+        //<inheritDoc/>
         public string PreprocessorVersion
         {
             get
@@ -361,6 +370,7 @@ namespace Xbim.Common.Step21
             }
         }
 
+        //<inheritDoc/>
         public string OriginatingSystem
         {
             get
@@ -374,6 +384,7 @@ namespace Xbim.Common.Step21
             }
         }
 
+        //<inheritDoc/>
         public string AuthorizationName
         {
             get
@@ -386,7 +397,7 @@ namespace Xbim.Common.Step21
                 OnPropertyChanged("AuthorizationName");
             }
         }
-
+        //<inheritDoc/>
         public IList<string> AuthorizationMailingAddress
         {
             get
@@ -489,6 +500,7 @@ namespace Xbim.Common.Step21
             }
         }
 
+        //<inheritDoc/>
         IList<string> IStepFileSchema.Schemas
         {
             get
@@ -537,12 +549,15 @@ namespace Xbim.Common.Step21
         {
             if (mode == HeaderCreationMode.InitWithXbimDefaults)
             {
-                var assembly = model.GetType().GetTypeInfo().Assembly; //get the assembly that has created the model
+                var xbimAssembly = model.GetType().GetTypeInfo().Assembly;
+                var appAssembly = Assembly.GetEntryAssembly() ?? xbimAssembly; //get the assembly that has created the model
+                var xbimInfo = new XbimAssemblyInfo(xbimAssembly);
+                var appInfo = new XbimAssemblyInfo(appAssembly);
                 FileDescription = new StepFileDescription("2;1");
-                FileName = new StepFileName(DateTime.Now)
+                FileName = new StepFileName(DateTime.UtcNow)
                 {
-                    PreprocessorVersion =$"Processor version {assembly.GetName().Version}",
-                    OriginatingSystem = assembly.GetName().Name
+                    PreprocessorVersion = $"xbim Toolkit v{xbimInfo.FileVersion}",
+                    OriginatingSystem = $"{appAssembly.GetName().Name} v{appInfo.FileVersion}"
                 };
                 FileSchema = new StepFileSchema();
             }

--- a/Xbim.Essentials.NetCore.Tests/FluentModelGeneratorTests.cs
+++ b/Xbim.Essentials.NetCore.Tests/FluentModelGeneratorTests.cs
@@ -384,6 +384,71 @@ namespace Xbim.Essentials.NetCore.Tests
             results.Should().HaveCount(1).And.Satisfy(v => v.IssueSource == "OwnerHistory");
         }
 
+        [Fact]
+        public void Can_AddPropertySet()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                .CreateEntities(c => c.Wall().WithPropertySet("Pset_WallCommon"));
+
+            var wall = file.Model.Instances.OfType<IIfcWall>().First();
+
+            var pset = wall.GetPropertySet("Pset_WallCommon");
+
+            pset.Should().NotBeNull();
+            pset.HasProperties.Should().BeEmpty();
+
+        }
+
+        [Fact]
+        public void Can_SetTextProperties()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                .CreateEntities(c => c.Wall().WithPropertySingle("Pset_WallCommon", "Reference", new Ifc4.MeasureResource.IfcText("Test")));
+
+            var wall = file.Model.Instances.OfType<IIfcWall>().First();
+
+            var prop = wall.GetPropertySingleValue("Pset_WallCommon", "Reference");
+
+            prop.Should().NotBeNull();
+            prop.NominalValue.Value.Should().Be("Test");   
+        }
+
+        [Fact]
+        public void Can_SetBooleanProperties()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                .CreateEntities(c => c.Wall().WithPropertySingle("Pset_WallCommon", "IsExternal", new Ifc4.MeasureResource.IfcBoolean(true)));
+
+            var wall = file.Model.Instances.OfType<IIfcWall>().First();
+
+            var prop = wall.GetPropertySingleValue("Pset_WallCommon", "IsExternal");
+
+            prop.Should().NotBeNull();
+            prop.NominalValue.Value.Should().Be(true);
+        }
+
+        [Fact]
+        public void Can_SetLengthProperties()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                .CreateEntities(c => c.Wall().WithPropertySingle("Pset_WallCommon","NominalHeight", new Ifc4.MeasureResource.IfcLengthMeasure(1.23d)));
+
+            var wall = file.Model.Instances.OfType<IIfcWall>().First();
+
+            var prop = wall.GetPropertySingleValue("Pset_WallCommon", "NominalHeight");
+
+            prop.Should().NotBeNull();
+            prop.NominalValue.Value.Should().Be(1.23d);
+        }
+
         private static XbimEditorCredentials GetEditor()
         {
             var editor = new XbimEditorCredentials

--- a/Xbim.Essentials.NetCore.Tests/FluentModelGeneratorTests.cs
+++ b/Xbim.Essentials.NetCore.Tests/FluentModelGeneratorTests.cs
@@ -1,0 +1,427 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xbim.Common.Exceptions;
+using Xbim.Common.Step21;
+using Xbim.Ifc;
+using Xbim.Ifc.Fluent;
+using Xbim.Ifc4.Interfaces;
+using Xbim.IO.Memory;
+using Xunit;
+
+
+namespace Xbim.Essentials.NetCore.Tests
+{
+    public class FluentModelGeneratorTests :IDisposable
+    {
+        // Latest file
+        public string IfcFile { get => files.Peek(); }
+
+        // Stack of files to clean up in Dispose
+        public Stack<string> files = new();
+
+        public FluentModelGeneratorTests()
+        {
+            NewTestFile();
+        }
+
+        private void NewTestFile(string file = null)
+        {
+            file ??= Path.ChangeExtension(Path.GetTempFileName(), "ifc");
+            files.Push(file);
+        }
+
+        [Fact]
+        public void NonFluentTest()
+        {
+            // How we'd normally build a model, with some helpers to populate default attribs (GlobalID etc)
+            using var model = new MemoryModel(new Ifc2x3.EntityFactoryIfc2x3());
+            using var trans = model.BeginTransaction("Create");
+
+            model.AddHeaders(IfcFile);
+      
+            var type = model.Build().WallType().WithDefaults();
+
+            var instance = model.Build().Wall().WithDefaults(t => t with { PredefinedType = "X" });
+            instance.AddDefiningType(type).WithDefaults();
+
+            trans.Commit();
+            using var sw = new FileStream(IfcFile, FileMode.Create);
+            model.SaveAsIfc(sw);
+        }
+
+        [Fact]
+        public void FluentEquivalentTest()
+        {
+            new FluentModelBuilder()
+                .CreateModel(XbimSchemaVersion.Ifc2X3)
+                .CreateEntities(cfg =>
+                {
+                    var type = cfg.WallType();
+                    cfg.Wall().WithDefaults(t => t with { PredefinedType = "X" })
+                        .AddDefiningType(type);
+                })
+                .SaveAsIfc(IfcFile);
+        }
+
+        [Fact]
+        public void FluentBuilderTest()
+        {
+            var builder = new FluentModelBuilder();
+            XbimEditorCredentials editor = GetEditor();
+
+            NewTestFile("wall.ifc");
+            builder.AssignEditor(editor)
+                .CreateModel(XbimSchemaVersion.Ifc2X3)
+                .SetHeaders()
+                .SetOwnerHistory()
+                .CreateEntities(cfg =>
+                {
+                    var type = cfg.WallType(o => o.WithDefaults(t => t with { Name = "Block"}));
+                    cfg.Wall(o => o.WithDefaults(t => t with { PredefinedType = "XYZ" }))
+                        .AddDefiningType(type);
+                })
+                .AssertValid()
+                .SaveAsIfc(IfcFile);
+
+            NewTestFile("sensor.ifc");
+            builder.CreateModel(XbimSchemaVersion.Ifc4)
+                .SetHeaders()
+                .SetOwnerHistory()
+                .CreateEntities((factory, ctx) =>
+                {
+                    var type = factory.SensorType(o => o.WithDefaults(t => t with { Name = "Light Sensor", PredefinedType= "LIGHTSENSOR" }));
+                    // using context for more precise control. (Builder doesn't support IFC4+ types)
+                    ctx.Instances.New<Ifc4.BuildingControlsDomain.IfcSensor>()
+                        .AddDefiningType(type);
+                })
+                .AssertValid()
+                .SaveAsIfc(IfcFile);
+        }
+
+        [Fact]
+        public void ShouldPopulateAttributes_Automatically()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                .CreateEntities(c => c.Door());
+
+            var door = file.Model.Instances.OfType<IIfcDoor>().First();
+
+            door.GlobalId.Should().NotBeNull();
+        }
+
+        [InlineData(XbimSchemaVersion.Ifc2X3)]
+        [InlineData(XbimSchemaVersion.Ifc4)]
+        [InlineData(XbimSchemaVersion.Ifc4x3)]
+        [Theory]
+        public void ShouldDefaultPredefinedTypesConsistently(XbimSchemaVersion schema)
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel(schema)
+                .CreateEntities(c => c.WallType());
+
+            var beam = file.Model.Instances.OfType<IIfcWallType>().First();
+            beam.GetPredefinedTypeValue().Should().Be("NOTDEFINED", "We override the default which is essentially random");
+        }
+
+        [Fact]
+        public void Should_AllowAttributes_To_Be_Set()
+        {
+            var builder = new FluentModelBuilder();
+            
+            var file = builder.CreateModel()
+                .CreateEntities(c => c.Beam().WithDefaults(a => a with { Name = "A", Description="B" }));
+
+            var beam = file.Model.Instances.OfType<IIfcBeam>().First();
+
+            beam.Name.ToString().Should().Be("A");
+            beam.Description.ToString().Should().Be("B");
+            beam.OwnerHistory.Should().BeNull("Not set explicitly");
+        }
+
+        [Fact]
+        public void Should_Allow_PredefinedType_To_Be_Sets()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                .CreateEntities(c => c.Pile().WithDefaults(a => a with { PredefinedType = "COHESION" }));
+
+            var pile = file.Model.Instances.OfType<IIfcPile>().First();
+
+            pile.PredefinedType.Should().Be(IfcPileTypeEnum.COHESION);
+        }
+
+
+        [Fact]
+        public void Should_Allow_ObjectType_To_Be_Set_Implicitly()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                .CreateEntities(c => c.Pile().WithDefaults(a => a with { PredefinedType = "Precast123" }));
+
+            var pile = file.Model.Instances.OfType<IIfcPile>().First();
+
+            pile.ObjectType.ToString().Should().Be("Precast123");
+            pile.PredefinedType.Should().Be(IfcPileTypeEnum.USERDEFINED);
+        }
+
+        [Fact]
+        public void Should_Allow_ObjectType_To_Be_Set_Implicitly_Without_PDT()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                .CreateEntities(c => c.Wall().WithDefaults(a => a with { PredefinedType = "Partition" }));
+
+            var wall = file.Model.Instances.OfType<IIfcWall>().First();
+
+            wall.ObjectType.ToString().Should().Be("Partition");
+            wall.PredefinedType.Should().BeNull("IfcWall.PredefinedType doesn't exist in 2x3");
+        }
+
+
+        [Fact]
+        public void Should_Allow_PredefinedType_To_Be_Set_ForTypes()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                .CreateEntities(c => c.BeamType().WithDefaults(a => a with { PredefinedType = "Joist" }));
+
+            var beam = file.Model.Instances.OfType<IIfcBeamType>().First();
+
+            beam.PredefinedType.Should().Be(IfcBeamTypeEnum.JOIST);
+        }
+
+        [Fact]
+        public void Should_Allow_ElementType_To_Be_Set_Implicitly()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                .CreateEntities(c => c.BeamType().WithDefaults(a => a with { PredefinedType = "I-Beam123" }));
+
+            var beam = file.Model.Instances.OfType<IIfcBeamType>().First();
+
+            beam.ElementType.ToString().Should().Be("I-Beam123");
+            beam.PredefinedType.Should().Be(IfcBeamTypeEnum.USERDEFINED);
+        }
+
+        [Fact]
+        public void Can_Set_OwnerHistory_OnModel()
+        {
+            var builder = new FluentModelBuilder();
+            var editor = GetEditor();
+
+            var file = builder.CreateModel()
+                .SetOwnerHistory(editor)
+                .CreateEntities(c => c.BeamType());
+
+            var beam = file.Model.Instances.OfType<IIfcBeamType>().First();
+
+            beam.OwnerHistory.Should().NotBeNull();
+            beam.OwnerHistory.ChangeAction.Should().Be(IfcChangeActionEnum.ADDED);
+            beam.OwnerHistory.OwningUser.ThePerson.GivenName.ToString().Should().Be("John");
+            beam.OwnerHistory.OwningUser.TheOrganization.Name.ToString().Should().Be("Acme");
+            beam.OwnerHistory.OwningApplication.ApplicationFullName.ToString().Should().Be("Sample app");
+        }
+
+        [Fact]
+        public void Can_Set_OwnerHistory_Globally()
+        {
+            var builder = new FluentModelBuilder();
+            var editor = GetEditor();
+
+            var file = builder
+                .AssignEditor(editor)   // Set once, each model inherits
+                .CreateModel()
+                .SetOwnerHistory()
+                .CreateEntities(c => c.Wall());
+
+            var item1 = file.Model.Instances.OfType<IIfcWall>().First();
+
+            item1.OwnerHistory.Should().NotBeNull();
+            item1.OwnerHistory.ChangeAction.Should().Be(IfcChangeActionEnum.ADDED);
+            item1.OwnerHistory.OwningUser.ThePerson.GivenName.ToString().Should().Be("John");
+
+            file.Discard(); // Create next File
+            file = builder
+                // Editor still in place
+                .CreateModel()
+                .SetOwnerHistory()
+                .CreateEntities(c => c.Window());
+
+            var item2 = file.Model.Instances.OfType<IIfcWindow>().First();
+
+            item2.OwnerHistory.Should().NotBeNull();
+            item2.OwnerHistory.ChangeAction.Should().Be(IfcChangeActionEnum.ADDED);
+            item2.OwnerHistory.OwningUser.ThePerson.GivenName.ToString().Should().Be("John");
+        }
+
+
+        [Fact]
+        public void Saving_Sets_FileName()
+        {
+            var builder = new FluentModelBuilder();
+            var editor = GetEditor();
+
+            builder.CreateModel()
+                .SetOwnerHistory(editor)
+                .CreateEntities(c => c.BeamType())
+                .SaveAsIfc(IfcFile);
+
+            var model = MemoryModel.OpenRead(IfcFile);
+            model.Header.FileName.Name.Should().Be(IfcFile);
+        }
+
+        [Fact]
+        public void ModelTransaction_Disposed_After_Saving()
+        {
+            var builder = new FluentModelBuilder();
+            var editor = GetEditor();
+
+            var fileBuilder = builder.CreateModel()
+                .SetOwnerHistory(editor)
+                .CreateEntities(c => c.BeamType())
+                .SaveAsIfc(IfcFile);
+
+            fileBuilder.Model.CurrentTransaction.Should().BeNull();
+
+            var ex = Record.Exception(() => fileBuilder.Model.Instances.New<Ifc2x3.SharedBldgElements.IfcBeam>());
+
+            ex.Should().NotBeNull().And.BeOfType<Exception>();
+            ex.Message.Should().Be("Operation out of transaction");
+        }
+
+        [Fact]
+        public void Can_Keep_Model_open_after_saving()
+        {
+            var builder = new FluentModelBuilder();
+            var editor = GetEditor();
+
+            var fileBuilder = builder.CreateModel()
+                .SetOwnerHistory(editor)
+                .CreateEntities(c => c.BeamType().WithDefaults(t => t with { Name = "A"}))
+                .SaveAsIfc(IfcFile, keepOpen: true);
+
+            NewTestFile();
+            fileBuilder
+                .CreateEntities((c, ctx) =>
+                {
+                    var beam = ctx.Instances.OfType<IIfcBeamType>().First();
+                    beam.SetAttributes(t => t with { Name = "B" });
+                    // Or 
+                    // beam.Name = "B";
+                })
+                .SaveAsIfc(IfcFile);
+
+            var model = MemoryModel.OpenRead(IfcFile);
+
+            var beamType = model.Instances.OfType<IIfcBeamType>().First();
+            beamType.Name.Value.Value.Should().Be("B");
+
+        }
+
+        [Fact]
+        public void Can_Set_Headers_from_Editor()
+        {
+            var builder = new FluentModelBuilder();
+            var editor = GetEditor();
+
+            builder
+                .AssignEditor(editor)
+                .CreateModel()
+                .SetHeaders()
+                .CreateEntities(c => c.BeamType())
+                .SaveAsIfc(IfcFile);
+            var dateNow = DateTime.UtcNow;
+
+            var model = MemoryModel.OpenRead(IfcFile);
+            model.Header.FileName.AuthorName.Should().HaveCount(1).And.BeEquivalentTo(new[] { "John Doe" });
+            model.Header.FileName.Organization.Should().HaveCount(1).And.BeEquivalentTo(new[] { "Acme" });
+
+            model.Header.FileName.OriginatingSystem.Should().Be("Sample app 1.2.3-alpha");
+            model.Header.FileName.PreprocessorVersion.Should().StartWith("xbim Toolkit v");
+            model.Header.FileName.TimeStamp.Should().StartWith(dateNow.ToString("yyyy-MM-ddTHH"));
+        }
+
+        [Fact]
+        public void Can_Assert_Model_Validity()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                // Don't set Owner History
+               // .SetOwnerHistory(GetEditor())
+                .CreateEntities(c => c.BeamType());
+
+            var ex = Record.Exception(() => file.AssertValid());
+
+            ex.Should().NotBeNull().And.BeOfType<XbimException>();
+            ex.Message.Should().StartWith("Model has 2 validation error(s):");
+
+        }
+
+        [Fact]
+        public void Can_ViewValidation_Results()
+        {
+            var builder = new FluentModelBuilder();
+
+            var file = builder.CreateModel()
+                // Don't set Owner History
+                //.SetOwnerHistory(GetEditor())
+                .CreateEntities(c => c.BeamType());
+
+            var results = file.ValidateIfc(Common.Enumerations.ValidationFlags.Properties);
+
+            results.Should().HaveCount(1).And.Satisfy(v => v.IssueSource == "OwnerHistory");
+        }
+
+        private static XbimEditorCredentials GetEditor()
+        {
+            var editor = new XbimEditorCredentials
+            {
+                EditorsGivenName = "John",
+                EditorsFamilyName = "Doe",
+                EditorsIdentifier = "john.doe@acme.com",
+                EditorsOrganisationName = "Acme",
+                EditorsOrganisationIdentifier = "com.acme",
+
+                ApplicationFullName = "Sample app",
+                ApplicationVersion = "1.2.3-alpha",
+                ApplicationDevelopersName = "Acme",  // When same as EditorOrg => reuses the org
+                ApplicationIdentifier = "sample-app"
+            };
+            return editor;
+        }
+
+        public void Dispose()
+        {
+            while(files.Any())
+            {
+                var file = files.Pop();
+                if(Path.IsPathRooted(file) && File.Exists(file))
+                {
+                    try
+                    {
+                        File.Delete(file);
+                    }
+                    catch { }
+                }
+            }
+        }
+    }
+
+    public static class WIP
+    {
+        
+    }
+
+}

--- a/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
+++ b/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-
+    <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
 
     <SignAssembly>true</SignAssembly>

--- a/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
+++ b/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>13</LangVersion>
+    <LangVersion>12</LangVersion>
     <IsPackable>false</IsPackable>
 
     <SignAssembly>true</SignAssembly>

--- a/Xbim.Ifc/Extensions/IIfcObjectExtensions.cs
+++ b/Xbim.Ifc/Extensions/IIfcObjectExtensions.cs
@@ -9,7 +9,8 @@ namespace Xbim.Ifc
     public static class IIfcObjectExtensions
     {
         /// <summary>
-        /// Adds an element type to the object if it doesn't already have one, return the new or existing relationship that holds the type and this element. If there is a relationship for this type but this element is not related it adds it to the exosting relationship
+        /// Adds an element type to the object if it doesn't already have one, return the new or existing relationship that holds the type and this element. 
+        /// If there is a relationship for this type but this element is not related it adds it to the existing relationship
         /// </summary>
         /// <param name="obj"></param>
         /// <param name="theType"></param>

--- a/Xbim.Ifc/Extensions/IfcStoreEditorExtensions.cs
+++ b/Xbim.Ifc/Extensions/IfcStoreEditorExtensions.cs
@@ -1,0 +1,105 @@
+﻿using System.Linq;
+using Xbim.Common;
+using Xbim.Ifc4.Interfaces;
+
+namespace Xbim.Ifc
+{
+    public static class IfcStoreEditorExtensions
+    {
+        /// <summary>
+        /// Gets a matching <see cref="IIfcApplication"/> creating a new one where no match exists
+        /// </summary>
+        /// <param name="model"></param>
+        /// <param name="editor"></param>
+        /// <param name="addDefaultRole">Flag indicating whether a default role is added</param>
+        /// <returns></returns>
+        public static IIfcApplication GetOrCreateApplication(this IModel model, XbimEditorCredentials editor, bool addDefaultRole = false)
+        {
+
+            if (editor == null)
+                return null;
+
+            var existingApplication = model.Instances.OfType<IIfcApplication>()
+                .Where(a => a.ApplicationFullName == editor.ApplicationFullName)
+                .Where(a => a.ApplicationIdentifier == editor.ApplicationIdentifier)
+                .Where(a => a.Version == editor.ApplicationVersion)
+                .FirstOrDefault();
+            if (existingApplication != null)
+            {
+                // use existing to avoid duplicate applications
+                return existingApplication;
+            }
+            else
+            {
+                // Create new application
+                var factory = new EntityCreator(model);
+                return factory.Application(a =>
+                {
+                    a.ApplicationDeveloper = model.Instances.OfType<IIfcOrganization>().FirstOrDefault(o => o.Name == editor.ApplicationDevelopersName)
+                        ?? factory.Organization(o =>
+                        {
+                            o.Name = editor.ApplicationDevelopersName;
+                            if(addDefaultRole)
+                            { 
+                                o.Roles.Add(factory.ActorRole(r =>
+                                {
+                                    r.Role = IfcRoleEnum.USERDEFINED;
+                                    r.UserDefinedRole = "Software Provider";
+                                }));
+                            }
+                        });
+                    a.ApplicationFullName = editor.ApplicationFullName;
+                    a.ApplicationIdentifier = editor.ApplicationIdentifier;
+                    a.Version = editor.ApplicationVersion;
+                });
+            }
+        }
+
+        /// <summary>
+        /// Gets <see cref="IIfcPersonAndOrganization"/> based on the <paramref name="editor"/>, creating a new one 
+        /// if no match exists.
+        /// </summary>
+        /// <param name="model"></param>
+        /// <param name="editor"></param>
+        /// <returns></returns>
+        public static IIfcPersonAndOrganization GetOrCreateDefaultUser(this IModel model, XbimEditorCredentials editor)
+        {
+            // data wasn't supplied to create default user and application
+            if (editor == null)
+                return null;
+
+            var factory = new EntityCreator(model);
+
+            var person = model.Instances.OfType<IIfcPerson>()
+                .FirstOrDefault(p => // Look up by identifier and then Given/Family name
+                    editor.EditorsIdentifier != null && p.Identification == editor.EditorsIdentifier ||
+                    (p.GivenName == editor.EditorsGivenName && p.FamilyName == editor.EditorsFamilyName))
+                ?? factory.Person(p =>
+                {
+                    p.Identification = editor.EditorsIdentifier;
+                    p.GivenName = editor.EditorsGivenName;
+                    p.FamilyName = editor.EditorsFamilyName;
+                });
+
+            var organization = model.Instances.OfType<IIfcOrganization>()
+                .FirstOrDefault(o => // Look up by identifier and then Organisation name
+                    editor.EditorsOrganisationIdentifier != null && o.Identification == editor.EditorsOrganisationIdentifier ||
+                    (o.Name == editor.EditorsOrganisationName))
+                ?? factory.Organization(o =>
+                {
+                    o.Name = editor.EditorsOrganisationName;
+                    o.Identification = editor.EditorsOrganisationIdentifier;
+                });
+            organization.Identification ??= editor.EditorsOrganisationIdentifier;
+            return
+                model.Instances.OfType<IIfcPersonAndOrganization>()
+                .FirstOrDefault(po => po.ThePerson == person && po.TheOrganization == organization)
+                ?? factory.PersonAndOrganization(po =>
+                {
+                    po.TheOrganization = organization;
+                    po.ThePerson = person;
+                });
+
+        }
+    }
+}

--- a/Xbim.Ifc/Fluent/EntityDefaults.cs
+++ b/Xbim.Ifc/Fluent/EntityDefaults.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Xbim.Ifc4.Interfaces;
+using Xbim.Ifc4.MeasureResource;
+
+namespace Xbim.Ifc.Fluent
+{
+#nullable enable
+    public record EntityDefaults()
+    {
+        public IfcLabel? Name { get; set; }
+        public IfcText? Description { get; set; }
+        public IIfcOwnerHistory? OwnerHistory { get; set; }
+        public Guid? GlobalId { get; set; }
+        public string? PredefinedType { get; set; }
+    }
+}

--- a/Xbim.Ifc/Fluent/FluentModelBuilder.cs
+++ b/Xbim.Ifc/Fluent/FluentModelBuilder.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Xbim.Common;
+using Xbim.Common.Step21;
+using Xbim.IO.Memory;
+
+namespace Xbim.Ifc.Fluent
+{
+#nullable enable
+
+    /// <summary>
+    /// A helper class to aid building valid cross-schema IFC models easily using a Fluent syntax
+    /// </summary>
+    /// <remarks>
+    /// Example usage
+    /// <code>
+    /// XbimEditorCredentials editor = GetEditor();
+    /// var builder = new FluentModelBuilder();
+    /// builder.AssignEditor(editor)
+    ///   .CreateModel(XbimSchemaVersion.Ifc2X3)
+    ///   .SetHeaders()
+    ///   .SetOwnerHistory()
+    ///   .CreateEntities(cfg =>
+    ///   {
+    ///      var type = cfg.Create().WallType();
+    ///      cfg.Create().Wall(o => o.WithAttributes(t => t with { PredefinedType = "XYZ" }))
+    ///        .AddDefiningType(type);
+    ///   })
+    ///   .SaveAsIfc("wall-with-type.ifc");
+    /// </code>
+    /// </remarks>
+    public class FluentModelBuilder
+    {
+        /// <summary>
+        /// The global editor in use across all models created with this Builder
+        /// </summary>
+        public XbimEditorCredentials? Editor { get; private set; }
+
+        /// <summary>
+        /// Start building a new <see cref="IModel"/>
+        /// </summary>
+        /// <param name="schemaVersion"></param>
+        /// <returns></returns>
+        public IModelFileBuilder CreateModel(XbimSchemaVersion schemaVersion = XbimSchemaVersion.Ifc2X3)
+        {
+            var factory = GetFactory(schemaVersion);
+            var model = new MemoryModel(factory);
+            return new ModelFileBuilder(this, model);
+        }
+
+        /// <summary>
+        /// Assign a global editor
+        /// </summary>
+        /// <remarks>This will automatically set the OwnerHistory on created items and populate the STEP Headers if you invoke <see cref="IModelFileBuilderExtensions.SetHeaders(IModelFileBuilder, Action{IStepFileName}?, Action{IStepFileDescription}?)"/> 
+        /// or <see cref="IModelFileBuilderExtensions.SetOwnerHistory(IModelFileBuilder, XbimEditorCredentials?, Action{Ifc4.Interfaces.IIfcOwnerHistory}?)"/> on the
+        /// Model</remarks>
+        /// <param name="editor"></param>
+        /// <returns></returns>
+        public FluentModelBuilder AssignEditor(XbimEditorCredentials editor)
+        {
+            Editor = editor;
+            return this;
+        }
+
+        private IEntityFactory GetFactory(XbimSchemaVersion schemaVersion)
+        {
+            return schemaVersion switch
+            {
+                XbimSchemaVersion.Ifc2X3 => new Xbim.Ifc2x3.EntityFactoryIfc2x3(),
+                XbimSchemaVersion.Ifc4 => new Xbim.Ifc4.EntityFactoryIfc4(),
+                XbimSchemaVersion.Ifc4x1 => new Xbim.Ifc4.EntityFactoryIfc4x1(),
+                XbimSchemaVersion.Ifc4x3 => new Xbim.Ifc4x3.EntityFactoryIfc4x3Add2(),
+                _ => throw new NotSupportedException(schemaVersion.ToString())
+            };
+        }
+    }
+}

--- a/Xbim.Ifc/Fluent/IModelExtensions.cs
+++ b/Xbim.Ifc/Fluent/IModelExtensions.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using Xbim.Common;
+using Xbim.Common.Step21;
+using Xbim.Ifc4.Interfaces;
+
+namespace Xbim.Ifc.Fluent
+{
+#nullable enable
+    public static class IModelExtensions
+    {
+        /// <summary>
+        /// Adds a filename to the STEP headers
+        /// </summary>
+        /// <param name="model"></param>
+        /// <param name="filename"></param>
+        /// <returns></returns>
+        public static IModel AddHeaders(this IModel model, string? filename)
+        {
+            return model.AddHeaders(
+                f =>
+                {
+                    f.Name = filename;
+                },
+                fd => { }
+               );
+        }
+
+        /// <summary>
+        /// Adds STEP Headers to the <paramref name="model"/>
+        /// </summary>
+        /// <param name="model"></param>
+        /// <param name="fileNameAction"></param>
+        /// <param name="fileDescriptionAction"></param>
+        /// <returns></returns>
+        public static IModel AddHeaders(this IModel model, Action<IStepFileName> fileNameAction, Action<IStepFileDescription> fileDescriptionAction)
+        {
+            fileDescriptionAction(model.Header.FileDescription);
+            fileNameAction(model.Header.FileName);
+            return model;
+        }
+
+        public static EntityCreator Build(this IModel model)
+        {
+            return new EntityCreator(model);
+        }
+
+        /// <summary>
+        /// Set attributes on an entity where the attribute setter value is non-null
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="entity"></param>
+        /// <param name="setter"></param>
+        /// <returns></returns>
+        public static T SetAttributes<T>(this T entity, Func<EntityDefaults, EntityDefaults> setter) where T : IIfcRoot
+        {
+            setter ??= (x) => x;
+            var entityDefaults = setter(new EntityDefaults());
+
+            return entity.SetAttributes(entityDefaults);
+        }
+
+        /// <summary>
+        /// Set attributes on an entity where the attribute setter value is non-null
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="entity"></param>
+        /// <param name="setter"></param>
+        /// <returns></returns>
+        public static T SetAttributes<T>(this T entity, EntityDefaults? setter = default) where T : IIfcRoot
+        {
+            setter ??= new EntityDefaults();
+            if(setter.GlobalId != Guid.Empty)
+                entity.SetGlobalId(setter.GlobalId);
+            if(string.IsNullOrEmpty(setter.Name) == false)
+                entity.Name = setter.Name;
+            if (string.IsNullOrEmpty(setter.Description) == false)
+                entity.Description = setter.Description;
+            if(setter.OwnerHistory != null)
+                entity.OwnerHistory ??= setter.OwnerHistory;
+            if(string.IsNullOrEmpty(setter.PredefinedType) == false)
+                SetPredefinedTypeValue(entity, setter);
+            return entity;
+        }
+
+        /// <summary>
+        /// Applies initial default attributes to an entity
+        /// </summary>
+        /// <remarks>PredefinedType is always set</remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="entity"></param>
+        /// <param name="initAction"></param>
+        /// <returns></returns>
+        public static T WithDefaults<T>(this T entity, Func<EntityDefaults, EntityDefaults> initAction) where T : IIfcRoot
+        {
+            initAction ??= (x) => x;
+            var entityDefaults = initAction(new EntityDefaults());
+
+            return entity.WithDefaults(entityDefaults);
+        }
+
+        /// <summary>
+        /// Applies initial default attributes to an entity
+        /// </summary>
+        /// <remarks>PredefinedType is always set</remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="entity"></param>
+        /// <param name="init"></param>
+        /// <returns></returns>
+        public static T WithDefaults<T>(this T entity, EntityDefaults? init = default) where T : IIfcRoot
+        {
+            init ??= new EntityDefaults();
+            if(entity.GlobalId == null)
+                entity.SetGlobalId(init.GlobalId);
+            entity.Name ??= init.Name;
+            entity.Description ??= init.Description;
+            entity.OwnerHistory ??= init.OwnerHistory;
+            SetPredefinedTypeValue(entity, init);   // Always set because non-null enums have a default value.
+            return entity;
+        }
+
+        private static void SetPredefinedTypeValue<T>(T entity, EntityDefaults init) where T : IIfcRoot
+        {
+            if (entity is IIfcObjectDefinition obj)
+            {
+                if (string.IsNullOrEmpty(init.PredefinedType))
+                {
+                    // Set Undefined since the default enum is arbitrary across schemas
+                    // See https://github.com/xBimTeam/XbimEssentials/issues/576
+                    obj.SetPredefinedTypeValue("NOTDEFINED");
+                }
+                else
+                {
+
+                    if (obj.IsPredefinedTypeEnum(init.PredefinedType))
+                    {
+                        // Built in standard PDT
+                        obj.SetPredefinedTypeValue(init.PredefinedType);
+                    }
+                    else
+                    {
+                        // User defined PDT where the actual value is stored in ObjectType/ElementType etc
+                        if (obj is IIfcObject o)
+                        {
+                            o.ObjectType = init.PredefinedType;
+                        }
+                        else if (obj is IIfcElementType t)
+                        {
+                            t.ElementType = init.PredefinedType;
+                        }
+                        else if (obj is IIfcTypeProcess p)
+                        {
+                            p.ProcessType = init.PredefinedType;
+                        }
+                        obj.SetPredefinedTypeValue("USERDEFINED");
+                    }
+                }
+            }
+        }
+        private static void SetGlobalId(this IIfcRoot entity, Guid? guid = default)
+        {
+            guid ??= Guid.NewGuid();
+            entity.GlobalId = Xbim.Ifc2x3.UtilityResource.IfcGloballyUniqueId.ConvertToBase64(guid.Value);
+        }
+
+
+    }
+}

--- a/Xbim.Ifc/Fluent/IModelExtensions.cs
+++ b/Xbim.Ifc/Fluent/IModelExtensions.cs
@@ -2,6 +2,7 @@
 using Xbim.Common;
 using Xbim.Common.Step21;
 using Xbim.Ifc4.Interfaces;
+using Xbim.Ifc;
 
 namespace Xbim.Ifc.Fluent
 {
@@ -117,6 +118,43 @@ namespace Xbim.Ifc.Fluent
             SetPredefinedTypeValue(entity, init);   // Always set because non-null enums have a default value.
             return entity;
         }
+
+        /// <summary>
+        /// Creates a PropertySet associated with this entity, if not already existing
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="entity"></param>
+        /// <param name="propertySet"></param>
+        /// <returns></returns>
+        public static T WithPropertySet<T>(this T entity, string propertySet) where T : IIfcObject
+        {
+            var pset = entity.GetPropertySet(propertySet);
+            if(pset == null)
+            {
+                pset = entity.Model.Build().PropertySet(o => o.Name = propertySet);
+            }
+            entity.AddPropertySet(pset);
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Creates a PropertySingleValue for an entity in the given PropertySet with the supplied Name and Value
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="entity"></param>
+        /// <param name="propertySet"></param>
+        /// <param name="propertyName"></param>
+        /// <param name="ifcValue"></param>
+        /// <returns></returns>
+        public static T WithPropertySingle<T>(this T entity, string propertySet, string propertyName, IIfcValue ifcValue) where T : IIfcObject
+        {
+            var type = ifcValue.GetType();
+            entity.SetPropertySingleValue(propertySet, propertyName, type).NominalValue = ifcValue;
+
+            return entity;
+        }
+
 
         private static void SetPredefinedTypeValue<T>(T entity, EntityDefaults init) where T : IIfcRoot
         {

--- a/Xbim.Ifc/Fluent/IModelFileBuilder.cs
+++ b/Xbim.Ifc/Fluent/IModelFileBuilder.cs
@@ -1,0 +1,38 @@
+﻿using Xbim.Common;
+using Xbim.Ifc4.Interfaces;
+
+namespace Xbim.Ifc.Fluent
+{
+#nullable enable
+    /// <summary>
+    /// Interface used in building individual Model files
+    /// </summary>
+    public interface IModelFileBuilder
+    {
+        /// <summary>
+        /// The <see cref="IModel"/> being built
+        /// </summary>
+        IModel Model { get; }
+        /// <summary>
+        /// The current <see cref="ITransaction"/>
+        /// </summary>
+        ITransaction Transaction { get; }
+        /// <summary>
+        /// A Factory that can create cross schema entities for the model
+        /// </summary>
+        EntityCreator Factory { get; }
+        /// <summary>
+        /// The inherited editor details
+        /// </summary>
+        XbimEditorCredentials? Editor { get; }
+        /// <summary>
+        /// The current <see cref="IIfcOwnerHistory"/>
+        /// </summary>
+        IIfcOwnerHistory? OwnerHistory { get; set; }
+        /// <summary>
+        /// Sets a new <see cref="ITransaction"/> on the model
+        /// </summary>
+        /// <param name="name"></param>
+        void NewTransaction(string name = "");
+    }
+}

--- a/Xbim.Ifc/Fluent/IModelFileBuilderExtensions.cs
+++ b/Xbim.Ifc/Fluent/IModelFileBuilderExtensions.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xbim.Common.Exceptions;
+using Xbim.Common.Step21;
+using Xbim.Ifc4.Interfaces;
+
+namespace Xbim.Ifc.Fluent
+{
+    public static class IModelFileBuilderExtensions
+    {
+#nullable enable
+
+        /// <summary>
+        /// Sets up a new OwnerHistory for this model, based on the supplied <see cref="XbimEditorCredentials"/>, which will be applied to all
+        /// subsequently added entities.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="editor">Optional editor. Falls back to <see cref="FluentModelBuilder.Editor"/> when omitted</param>
+        /// <param name="action">Optional Action to amend the default OwnerHistory</param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        public static IModelFileBuilder SetOwnerHistory(this IModelFileBuilder builder, XbimEditorCredentials? editor = null, Action<IIfcOwnerHistory>? action = null)
+        {
+            editor ??= builder.Editor ?? throw new Exception("An editor must be defined to set OwnerHistory");
+            var app = builder.Model.GetOrCreateApplication(editor);
+            var user = builder.Model.GetOrCreateDefaultUser(editor);
+
+            Func<IIfcOwnerHistory, IIfcOwnerHistory>? defaultValue = o =>
+            {
+                o.ChangeAction = IfcChangeActionEnum.ADDED;
+                o.State = IfcStateEnum.READWRITE;
+                o.OwningApplication = app;
+                o.OwningUser = user;
+                o.CreationDate = DateTime.UtcNow;
+                o.LastModifiedDate = DateTime.UtcNow;
+                return o;
+            };
+
+            action ??= _ => { };
+
+            builder.OwnerHistory = builder.Factory.OwnerHistory(o => action(defaultValue(o)));
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Sets the IFC STEP headers using the default <see cref="FluentModelBuilder.Editor"/> parameters for Author, Organisation and OrignatingSystem
+        /// when supplied
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="stepFileName">Action to amend the FileName explicitly</param>
+        /// <param name="fileDescription">Action to amend the Files Description (MVD) explicitly</param>
+        /// <returns></returns>
+        public static IModelFileBuilder SetHeaders(this IModelFileBuilder builder, Action<IStepFileName>? stepFileName = null, Action<IStepFileDescription>? fileDescription = null)
+        {
+            fileDescription ??= fd => fd.Description.Add("ViewDefinition [CoordinationView]");
+            stepFileName ??= f =>
+            {
+                f.OriginatingSystem = $"{builder.Editor?.ApplicationFullName ?? "xbim Toolkit"} {builder.Editor?.ApplicationVersion}";
+                if (builder.Editor != null)
+                {
+                    f.AuthorName.Add($"{builder.Editor.EditorsGivenName} {builder.Editor.EditorsFamilyName}");
+                    f.Organization.Add($"{builder.Editor.EditorsOrganisationName}");
+                }
+            };
+            builder.Model.AddHeaders(stepFileName, fileDescription);
+            return builder;
+        }
+
+        /// <summary>
+        /// Saves the current Model to STEP IFC to the specified <paramref name="fileName"/> path.
+        /// </summary>
+        /// <remarks><para>Any existing file will be over-written.</para> 
+        /// <para>By default the model and transaction will be closed. This 
+        /// behaviour can be over-ridden by setting <paramref name="keepOpen"/> to <c>true</c></para>
+        /// </remarks>
+        /// <param name="fileBuilder"></param>
+        /// <param name="fileName">The *.ifc filename &amp; path to save to</param>
+        /// <param name="keepOpen"></param>
+        public static IModelFileBuilder SaveAsIfc(this IModelFileBuilder fileBuilder, string fileName, bool keepOpen = false)
+        {
+            fileBuilder.Model.Header.FileName.Name = fileName;
+            fileBuilder.Transaction.Commit();
+
+            using var sw = new FileStream(fileName, FileMode.Create);
+            fileBuilder.Model.SaveAsIfc(sw);
+            if (keepOpen == false)
+                fileBuilder.Discard();
+            else
+                fileBuilder.NewTransaction();
+
+            return fileBuilder;
+        }
+
+        /// <summary>
+        /// Initiates building of the models entities using provided Factory 
+        /// </summary>
+        /// <param name="fileBuilder"></param>
+        /// <param name="config">Action to build the entities, using <see cref="IModelFileBuilder.Factory"/></param>
+        /// <returns>The <see cref="IModelFileBuilder"/></returns>
+        public static IModelFileBuilder CreateEntities(this IModelFileBuilder fileBuilder, Action<EntityCreator> config)
+        {
+            var builder = new ModelInstanceBuilder(fileBuilder);
+            config(builder.Factory);
+            return fileBuilder;
+        }
+
+        /// <summary>
+        /// Initiates building of the models entities using provided Factory 
+        /// </summary>
+        /// <param name="fileBuilder"></param>
+        /// <param name="config">Action to build the entities, using <see cref="IModelFileBuilder.Factory"/></param>
+        /// <returns>The <see cref="IModelFileBuilder"/></returns>
+        public static IModelFileBuilder CreateEntities(this IModelFileBuilder fileBuilder, Action<EntityCreator, IModelInstanceBuilder> config)
+        {
+            var builder = new ModelInstanceBuilder(fileBuilder);
+            config(builder.Factory, builder);
+            return fileBuilder;
+        }
+
+        /// <summary>
+        /// Discards the built model &amp; transaction, freeing up resources
+        /// </summary>
+        /// <remarks>For test purposes.</remarks>
+        /// <param name="fileBuilder"></param>
+        public static void Discard(this IModelFileBuilder fileBuilder)
+        {
+            (fileBuilder as IDisposable)!.Dispose();
+        }
+
+        /// <summary>
+        /// Validates the model and provides the set of errors for the given <paramref name="validationFlags"/>
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="validationFlags">Flags determining level of validation to undertake. Defaults to <see cref="Common.Enumerations.ValidationFlags.All"/></param>
+        /// <returns>The set of validation results</returns>
+        public static IEnumerable<Common.ExpressValidation.ValidationResult> ValidateIfc(this IModelFileBuilder builder, Common.Enumerations.ValidationFlags validationFlags = Common.Enumerations.ValidationFlags.All)
+        {
+            var validator = new Xbim.Common.ExpressValidation.Validator();
+            validator.ValidateLevel = validationFlags;
+            var results = validator.Validate(builder.Model);
+
+            return results;
+        }
+
+        /// <summary>
+        /// Asserts the model is valid IFC to the level specified by the <paramref name="validationFlags"/>
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="validationFlags"></param>
+        /// <returns></returns>
+        /// <exception cref="XbimException">Thrown when errors exist</exception>
+        public static IModelFileBuilder AssertValid(this IModelFileBuilder builder, Common.Enumerations.ValidationFlags validationFlags = Common.Enumerations.ValidationFlags.All)
+        {
+            var results = builder.ValidateIfc(validationFlags);
+            if (results.Any())
+            {
+                var topErrors = results.Take(10).Select(e => $"[{e.IssueSource}] {e.Message}: {e.Item}").ToList();
+                var errors = string.Join("\n", topErrors);
+                throw new XbimException($"Model has {results.Count()} validation error(s): \n{errors}");
+            }
+            return builder;
+        }
+    }
+}

--- a/Xbim.Ifc/Fluent/IModelInstanceBuilder.cs
+++ b/Xbim.Ifc/Fluent/IModelInstanceBuilder.cs
@@ -1,0 +1,26 @@
+﻿using Xbim.Common;
+using Xbim.Ifc4.Interfaces;
+
+namespace Xbim.Ifc.Fluent
+{
+    /// <summary>
+    /// Interface used to allow fluent building instances on a model
+    /// </summary>
+    public interface IModelInstanceBuilder
+    {
+        /// <summary>
+        /// The Instances in the model
+        /// </summary>
+        IEntityCollection Instances { get; }
+
+        /// <summary>
+        /// The entire model object
+        /// </summary>
+        IModel Model { get; }
+
+        /// <summary>
+        /// An <see cref="IEntityFactory"/> built for this model, enabling easy cross-schema creation of entities.
+        /// </summary>
+        EntityCreator Factory { get; }
+    }
+}

--- a/Xbim.Ifc/Fluent/ModelFileBuilder.cs
+++ b/Xbim.Ifc/Fluent/ModelFileBuilder.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using Xbim.Common;
+using Xbim.Ifc4.Interfaces;
+
+namespace Xbim.Ifc.Fluent
+{
+#nullable enable
+    /// <summary>
+    /// Builds a Model, ensuring new entities have OwnerHistory and defaults applied if specified
+    /// </summary>
+    public class ModelFileBuilder : IModelFileBuilder, IDisposable
+    {
+        // <inheritDocs>
+        public IModel Model { get; }
+        // <inheritDocs>
+        public EntityCreator Factory { get; }
+        // <inheritDocs>
+        public ITransaction Transaction { get; private set; }
+        // <inheritDocs>
+        public XbimEditorCredentials? Editor { get; }
+        // <inheritDocs>
+        public IIfcOwnerHistory? OwnerHistory { get; set; }
+
+        private bool disposedValue;
+
+        /// <summary>
+        /// Constructs a new <see cref="ModelFileBuilder"/>
+        /// </summary>
+        /// <param name="parent"></param>
+        /// <param name="model"></param>
+        public ModelFileBuilder(FluentModelBuilder parent, IModel model)
+        {
+            Model = model;
+            Factory = new EntityCreator(model);
+            Editor = parent.Editor;
+            Transaction = Model.BeginTransaction("Fluent Builder");
+
+            model.EntityNew += EntityAdded;
+        }
+
+        /// <summary>
+        /// Creates a new transaction
+        /// </summary>
+        /// <remarks>For use after a model has been Saved, enabling re-use of prior instances</remarks>
+        /// <param name="name"></param>
+        /// <exception cref="InvalidOperationException">Raised if a transaction already exists</exception>
+        public void NewTransaction(string name = "")
+        {
+            if(Model.CurrentTransaction != null)
+            {
+                throw new InvalidOperationException("A transaction already exists");
+            }
+            Transaction = Model.BeginTransaction(name ?? "Fluent Builder");
+        }
+
+        private void EntityAdded(IPersistEntity entity)
+        {
+            if (entity is IIfcRoot root)
+            {
+                root.WithDefaults(t => t with { GlobalId = Guid.NewGuid(), OwnerHistory = OwnerHistory });
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    Model.EntityNew -= EntityAdded;
+                    Transaction.Dispose();
+                    Model.Dispose();
+                }
+                disposedValue = true;
+            }
+        }
+        // <inheritDocs>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Xbim.Ifc/Fluent/ModelInstanceBuilder.cs
+++ b/Xbim.Ifc/Fluent/ModelInstanceBuilder.cs
@@ -1,0 +1,21 @@
+﻿using Xbim.Common;
+using Xbim.Ifc4.Interfaces;
+
+namespace Xbim.Ifc.Fluent
+{
+    public class ModelInstanceBuilder : IModelInstanceBuilder
+    {
+        public IModel Model { get => FileBuilder.Model; }
+
+        public EntityCreator Factory { get => FileBuilder.Factory; }
+        public IEntityCollection Instances { get => Model.Instances; }
+
+        protected IModelFileBuilder FileBuilder { get; }
+
+
+        public ModelInstanceBuilder(IModelFileBuilder fileBuilder)
+        {
+            FileBuilder = fileBuilder;
+        }
+    }
+}

--- a/Xbim.Ifc/Fluent/PropertyDefault.cs
+++ b/Xbim.Ifc/Fluent/PropertyDefault.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xbim.Ifc4.Interfaces;
+
+namespace Xbim.Ifc.Fluent
+{
+#nullable enable
+    public record PropertyDefault
+    {
+        public string? PropertySet { get; set; }
+        public string? Name { get; set; }
+        public IIfcValue? Value { get; set; }
+    }
+}

--- a/Xbim.Ifc4/Interfaces/Extensions/ObjectDefinitionExtensions.cs
+++ b/Xbim.Ifc4/Interfaces/Extensions/ObjectDefinitionExtensions.cs
@@ -10,6 +10,8 @@ namespace Xbim.Ifc4.Interfaces
 
         // A thread-safe cache between the type and a Getter for its PredefinedType property. By caching getters we elimiminate all Reflection
         static ConcurrentDictionary<Type, Func<object, object>> _predefinedGetterDict = new ConcurrentDictionary<Type, Func<object, object>>();
+        // A thread-safe cache between the type and a Setter for its PredefinedType property. By caching setters we elimiminate all Reflection
+        static ConcurrentDictionary<Type, (Type, Action<object, object>)> _predefinedSetterDict = new ConcurrentDictionary<Type, (Type, Action<object, object>)>();
 
         /// <summary>
         /// Gets the string value of any PredefinedType property on the <see cref="IIfcObjectDefinition"/> instance, if the type has one; else returns null
@@ -34,6 +36,93 @@ namespace Xbim.Ifc4.Interfaces
         }
 
         /// <summary>
+        /// Sets the PredefinedType property on the <see cref="IIfcObjectDefinition"/> instance, if the type has one.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="value"></param>
+        /// <returns><c>true</c> if set was successful else <c>false</c></returns>
+        public static bool SetPredefinedTypeValue(this IIfcObjectDefinition instance, string value)
+        {
+            if (instance is null)
+            {
+                return false;
+            }
+
+            //// Locate the setter for the PredefinedType property on this type from the cache, lazily creating one if not present
+            var (type, setter) = _predefinedSetterDict.GetOrAdd(instance.GetType(), (_) => BuildPredefinedTypeSetter(instance));
+            if(setter != null)
+            {
+                object enumValue = GetEnumValue(instance, value, type);
+                if(enumValue != null)
+                {
+                    setter(instance, enumValue);
+                    return true;
+                }
+            }
+            // this type has no PredefinedType property, or the enum was not applicable
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the <paramref name="value"/> is a known pre-defined enum on the <paramref name="instance"/>. 
+        /// The test is case-insensitive.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="value"></param>
+        /// <returns><c>true</c> if the value matches an enum; else <c>false</c></returns>
+        public static bool IsPredefinedTypeEnum(this IIfcObjectDefinition instance, string value)
+        {
+            if (instance is null)
+            {
+                return false;
+            }
+            var (type, setter) = _predefinedSetterDict.GetOrAdd(instance.GetType(), (_) => BuildPredefinedTypeSetter(instance));
+            if (setter != null)
+            {
+                return GetEnumValue(instance, value, type) != null;
+            }
+            return false;
+        }
+
+        private static object GetEnumValue(IIfcObjectDefinition instance, string value, Type enumType)
+        {
+            if (instance is null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            if (enumType != null && !string.IsNullOrEmpty(value))
+            {
+                try
+                {
+                    if(IsNullable(enumType))
+                    {
+                        enumType = Nullable.GetUnderlyingType(enumType);
+                    }
+                    var pdt = Enum.Parse(enumType, value, true);
+                    return pdt;
+                }
+                catch (System.ArgumentException) { }
+                catch (System.OverflowException) { }
+
+            }
+            return null;
+        }
+
+        private static bool IsNullable(Type type)
+        {
+            if(type.IsValueType)
+            {
+                // value types are only nullable if they are Nullable<T>
+                return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Returns a getter method for the PredefinedType property on the concrete type of the object
         /// </summary>
         /// <param name="obj"></param>
@@ -47,6 +136,23 @@ namespace Xbim.Ifc4.Interfaces
                 return predefinedMetadata.PropertyInfo.GetValue;
             }
             return null;
+        }
+
+        /// <summary>
+        /// Returns the Type and its setter method for the PredefinedType property on the concrete type of the object
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        private static (Type, Action<object, object>) BuildPredefinedTypeSetter(IIfcObjectDefinition obj)
+        {
+            var predefinedMetadata = obj.ExpressType.Properties.FirstOrDefault(p => p.Value.Name == PredefinedType).Value;
+            if (predefinedMetadata != null)
+            {
+                var type = predefinedMetadata.PropertyInfo.PropertyType;
+                // return the Type and the setter function - Input: 1) the instance as param 2) enum object. Output=void
+                return (type, predefinedMetadata.PropertyInfo.SetValue);
+            }
+            return (null, null);
         }
 
     }


### PR DESCRIPTION
A simple, extensible set of fluent methods to allow the creation of IFC files from code using xbim IModel implementations. E.g. useful for building test cases, examples etc. The approach helps build simple, valid and repeatable IFC STEP files with a succinct grammar.

Supports: Guid generation, Cross-schema support, easy IFC persistance, setting of headers, OwnerHistory, and test variations. Supports fluent, configurable validation using xbim's built-in validator to ensure files are syntactically correct and meet implementor agreements.