### PR TITLE
Work to speed-up SaveAs for Esent models

### DIFF
--- a/Tests/GeometryStoreTests.cs
+++ b/Tests/GeometryStoreTests.cs
@@ -107,11 +107,14 @@ namespace Xbim.IO.Tests
         [TestMethod]
         public void EsentGeometryStoreReopenAddTest()
         {
+            var testEsentFile = nameof(EsentGeometryStoreReopenAddTest) + ".xbim";
+            File.Delete(testEsentFile);
+
             var db = Guid.NewGuid().ToString() + ".xbim";
             var ifc = "TestFiles\\4walls1floorSite.ifc";
-            var p = new EsentModelProvider { DatabaseFileName = db };
-            var s = p.GetXbimSchemaVersion(ifc);
-            using (var m = p.Open(ifc, s)) { p.Close(m); }
+            var dbProvider = new EsentModelProvider { DatabaseFileName = db };
+            var schemaV = dbProvider.GetXbimSchemaVersion(ifc);
+            using (var m = dbProvider.Open(ifc, schemaV)) { dbProvider.Close(m); }
 
             using (var model = IfcStore.Open(db, accessMode: XbimDBAccess.ReadWrite))
             {
@@ -154,7 +157,7 @@ namespace Xbim.IO.Tests
 
                     txn.Commit();
                 }
-                model.SaveAs("SampleHouse4.xbim", StorageType.Xbim);
+                model.SaveAs(testEsentFile, StorageType.Xbim);
                 model.Close();
             }
         }
@@ -162,6 +165,8 @@ namespace Xbim.IO.Tests
         [TestMethod]
         public void IfcStoreGeometryStoreAddTest()
         {
+            var testEsentFile = nameof(IfcStoreGeometryStoreAddTest) + ".xbim";
+            File.Delete(testEsentFile);
             using (var model = IfcStore.Open("TestFiles\\SampleHouse4.ifc"))
             {
                 var geomStore = model.GeometryStore;
@@ -201,10 +206,10 @@ namespace Xbim.IO.Tests
 
                     txn.Commit();
                 }
-                model.SaveAs("SampleHouse4.xbim", StorageType.Xbim);
+                model.SaveAs(testEsentFile, StorageType.Xbim);
                 model.Close();
             }
-            using (var model = IfcStore.Open(@"SampleHouse4.xbim"))
+            using (var model = IfcStore.Open(testEsentFile))
             {
                 var geomStore = model.GeometryStore;
                 Assert.IsFalse(geomStore.IsEmpty);

--- a/Tests/ParsingTests.cs
+++ b/Tests/ParsingTests.cs
@@ -728,23 +728,28 @@ namespace Xbim.Essentials.Tests
         [TestMethod]
         public void IfcStoreSaveAsXbimTest()
         {
+            const string DoorEs = "4walls1floorSiteDoorES.xbim";
+            const string DoorEs2 = "4walls1floorSiteDoorES2.Ifc";
+            File.Delete(DoorEs);
+            File.Delete(DoorEs2);
             long originalCount;
             using (var ifcStore = IfcStore.Open("TestFiles\\4walls1floorSite.ifc", null, 0)) //test esent databases first
             {
                 var count = originalCount = ifcStore.Instances.Count;
                 Assert.IsTrue(count > 0, "Should have more than zero instances"); //read mode is working               
-                ifcStore.SaveAs("4walls1floorSiteDoorES.xbim");
+                
+                ifcStore.SaveAs(DoorEs);
                 ifcStore.Close();
             }
-
-            using (var ifcStore = IfcStore.Open("4walls1floorSiteDoorES.xbim")) //test esent databases first
+            using (var ifcStore = IfcStore.Open(DoorEs)) //test esent databases first
             {
                 var count = ifcStore.Instances.Count;
                 Assert.IsTrue(count > 0, "Should have more than zero instances"); //read mode is working                
-                ifcStore.SaveAs("4walls1floorSiteDoorES2.Ifc");
+                
+                ifcStore.SaveAs(DoorEs2);
                 ifcStore.Close();
             }
-            using (var ifcStore = IfcStore.Open("4walls1floorSiteDoorES2.ifc")) //test esent databases first
+            using (var ifcStore = IfcStore.Open(DoorEs2)) //test esent databases first
             {
                 var count = ifcStore.Instances.Count;
                 Assert.IsTrue(count == originalCount, "Should have more than zero instances"); //read mode is working                              

--- a/Tests/Xbim.Essentials.Tests.csproj
+++ b/Tests/Xbim.Essentials.Tests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.2.0]" /><!-- locked at 7.2.0 to avoid licensing changes of 8.0.0 -->
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />

--- a/Xbim.Essentials.NetCore.Tests/EsentTests.cs
+++ b/Xbim.Essentials.NetCore.Tests/EsentTests.cs
@@ -1,5 +1,9 @@
 ﻿using FluentAssertions;
+using System.IO;
+using System.Linq;
+using Xbim.Ifc;
 using Xbim.Ifc4;
+using Xbim.IO.Esent;
 using Xunit;
 
 namespace Xbim.Essentials.NetCore.Tests
@@ -10,8 +14,24 @@ namespace Xbim.Essentials.NetCore.Tests
         public void CanCreateEsentModel()
         {
             var esentModel = new Xbim.IO.Esent.EsentModel(new EntityFactoryIfc4());
-
             esentModel.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void EsentShouldOptimiseSaveAs()
+        {
+            var file = @"TestFiles\SampleHouse4.ifc";
+            var esentModelFile = Path.ChangeExtension(file, ".esent.xbim");
+            File.Delete(esentModelFile); // delete any existing file
+            using (var ifcStore = IfcStore.Open(file, null, 0)) // 0 is the database triggering threshold, test esent databases
+            {
+                var count = ifcStore.Instances.Count;
+                count.Should().BeGreaterThan(0, "original model is not empty");
+                ifcStore.SaveAs(esentModelFile);
+                ifcStore.Close();
+            }
+            File.Exists(esentModelFile).Should().BeTrue("model should be saved as esent file");
+            CoverageProbes.HeuristicModelProvider_EfficientEsentSaveasHit.Should().BeTrue("the efficient save-as path should have been hit");
         }
     }
 }

--- a/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
+++ b/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.0.1" />
+    <PackageReference Include="FluentAssertions" Version="[7.2.0]" /><!-- locked at 7.2.0 to avoid licensing changes of 8.0.0 -->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Xbim.IO.Esent/CoverageProbes.cs
+++ b/Xbim.IO.Esent/CoverageProbes.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+[assembly: InternalsVisibleTo("Xbim.Essentials.NetCore.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010029a3c6da60efcb3ebe48c3ce14a169b5fa08ffbf5f276392ffb2006a9a2d596f5929cf0e68568d14ac7cbe334440ca0b182be7fa6896d2a73036f24bca081b2427a8dec5689a97f3d62547acd5d471ee9f379540f338bbb0ae6a165b44b1ae34405624baa4388404bce6d3e30de128cec379147af363ce9c5845f4f92d405ed0")]
+
+namespace Xbim.IO.Esent
+{
+    /// <summary>
+    /// This class is used to hold coverage probes for the Xbim.IO.Esent library.
+    /// </summary>
+    internal static class CoverageProbes
+    {
+        /// <summary>
+        /// Ensures that the heuristic model provider uses the efficient save-as path.
+        /// </summary>
+        public static bool HeuristicModelProvider_EfficientEsentSaveasHit { get; set; } = false;
+    }
+}

--- a/Xbim.IO.Esent/HeuristicModelProvider.cs
+++ b/Xbim.IO.Esent/HeuristicModelProvider.cs
@@ -13,8 +13,6 @@ using System.Runtime.InteropServices;
 
 namespace Xbim.Ifc
 {
-
-
     /// <summary>
     /// The <see cref="HeuristicModelProvider"/> encapsulates the underlying <see cref="IModel"/> implementations we use 
     /// to provide different persistance performance characteristics, depending on the use-case and the consumer's inputs.
@@ -58,7 +56,6 @@ namespace Xbim.Ifc
         /// </summary>
         public override StoreCapabilities Capabilities => new StoreCapabilities(isTransient: false, supportsTransactions: true);
 
-
         /// <summary>
         /// Closes a Model store, releasing any resources
         /// </summary>
@@ -67,9 +64,7 @@ namespace Xbim.Ifc
         {
             if (model is EsentModel esentSub)
                 esentSub.Close();
-
             // memory models don't need closing
-
         }
 
         /// <summary>
@@ -83,7 +78,6 @@ namespace Xbim.Ifc
             var factory = GetFactory(ifcVersion);
             var model = EsentModel.CreateModel(factory, dbPath);
             return model;
-
         }
 
         /// <summary>
@@ -173,7 +167,6 @@ namespace Xbim.Ifc
         public override IModel Open(Stream stream, StorageType dataType, XbimSchemaVersion schema, XbimModelType modelType, 
             XbimDBAccess accessMode = XbimDBAccess.Read, ReportProgressDelegate progDelegate = null, int codePageOverride = -1)
         {
-
             if(modelType == XbimModelType.EsentModel  && ! IsEsentSupported())
             {
                 modelType = XbimModelType.MemoryModel;
@@ -362,6 +355,10 @@ namespace Xbim.Ifc
                 var fullTargetPath = Path.GetFullPath(fileName);
                 if (string.Compare(fullSourcePath, fullTargetPath, StringComparison.OrdinalIgnoreCase) == 0)
                     return; // do nothing - don't save on top of self
+                // use faster SaveAs method
+                CoverageProbes.HeuristicModelProvider_EfficientEsentSaveasHit = true;
+                esentModel.SaveAs(fileName, StorageType.Xbim, progDelegate);
+                return;
             }
 
             // Create a new Esent model for this Model => Model copy
@@ -387,8 +384,6 @@ namespace Xbim.Ifc
         {
             var factory = GetFactory(schema);
             return new MemoryModel(factory, _loggerFactory);
-        }
-
-        
+        }    
     }
 }

--- a/Xbim.Ifc/IfcStore.cs
+++ b/Xbim.Ifc/IfcStore.cs
@@ -637,7 +637,7 @@ namespace Xbim.Ifc
         /// Saves the model to the specified file
         /// </summary>
         /// <param name="fileName">Name of the file to save to, if no format is specified the extension is used to determine the format</param>
-        /// <param name="format">if specified saves in the required format and changes the extension to the correct one</param>
+        /// <param name="format">if specified, saves in the required format and changes the extension to the correct one</param>
         /// <param name="progDelegate">reports on progress</param>
         public void SaveAs(string fileName, StorageType? format = null, ReportProgressDelegate progDelegate = null)
         {
@@ -693,39 +693,34 @@ namespace Xbim.Ifc
                 }
             }
             var actualFileName = Path.ChangeExtension(fileName, extension);
-            
+
             SaveAs(actualFileName, actualFormat, progDelegate);
         }
 
         /// <summary>
         /// Saves / Exports the model to a given file with the provided model format
         /// </summary>
-        /// <param name="actualFileName"></param>
-        /// <param name="actualFormat">this will be correctly set</param>
-        /// <param name="progDelegate"></param>
-        private void SaveAs(string actualFileName, StorageType actualFormat, ReportProgressDelegate progDelegate)
-          {
-            FileName = actualFileName;
-            if (actualFormat.HasFlag(StorageType.Xbim)) //special case for xbim
+        private void SaveAs(string destinationFileName, StorageType requiredFormat, ReportProgressDelegate progDelegate)
+        {
+            FileName = destinationFileName;
+            if (requiredFormat.HasFlag(StorageType.Xbim)) //special case for xbim
             {
-                ModelProvider.Persist(Model, actualFileName, progDelegate);
+                ModelProvider.Persist(Model, destinationFileName, progDelegate);
             }
             else
             {
-                using (var fileStream = new FileStream(actualFileName, FileMode.Create, FileAccess.Write))
+                using (var fileStream = new FileStream(destinationFileName, FileMode.Create, FileAccess.Write))
                 {
-                    if (actualFormat.HasFlag(StorageType.IfcZip))
+                    if (requiredFormat.HasFlag(StorageType.IfcZip))
                         //do zip first so that xml and ifc are not confused by the combination of flags
-                        IfcStoreExportExtensions.SaveAsIfcZip(this, fileStream, Path.GetFileName(actualFileName), actualFormat, progDelegate);
-                    else if (actualFormat.HasFlag(StorageType.Ifc))
+                        IfcStoreExportExtensions.SaveAsIfcZip(this, fileStream, Path.GetFileName(destinationFileName), requiredFormat, progDelegate);
+                    else if (requiredFormat.HasFlag(StorageType.Ifc))
                         IfcStoreExportExtensions.SaveAsIfc(this, fileStream, progDelegate);
-                    else if (actualFormat.HasFlag(StorageType.IfcXml))
+                    else if (requiredFormat.HasFlag(StorageType.IfcXml))
                         IfcStoreExportExtensions.SaveAsIfcXml(this, fileStream, progDelegate);
-
                 }
             }
         }
-
 
         #region Referenced Models functions / Federation
 


### PR DESCRIPTION
When using HeuristicModelProvider the performance saving an esent file to another location was slow, because it did recreate the database. With this fix the built-in SaveAs is invoked, which performs faster file operations.

Also I've changed the version of FluentAssertions to avoid license issues with 8.0.0, which requires a paid license.

Minor changes to other test files to avoid conflicting xbim file names.