### PR TITLE
Use precise namespace segments comparison for registering schema types when creating ExpressMetaData

### DIFF
--- a/Tests/ExpressMetadataTests.cs
+++ b/Tests/ExpressMetadataTests.cs
@@ -16,9 +16,9 @@ namespace Xbim.Essentials.Tests
     {
         [InlineData(typeof(Xbim.Common.PersistEntity), 0)]  // Nothing defined in this schema
         [InlineData(typeof(Xbim.Ifc2x3.EntityFactoryIfc2x3), 771)]
-        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4), 932)]
-        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4x1), 932)]
-        [InlineData(typeof(Xbim.Ifc4x3.EntityFactoryIfc4x3Add2), 1007)]
+        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4), 933)]
+        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4x1), 933)]
+        [InlineData(typeof(Xbim.Ifc4x3.EntityFactoryIfc4x3Add2), 1008)]
         [Theory]
         [Obsolete]
         public void HasExpectedSchemaTypesByModule(Type moduleType, int expectedTypes)
@@ -27,14 +27,13 @@ namespace Xbim.Essentials.Tests
             var m = moduleType.GetTypeInfo().Module;
             var metaData = ExpressMetaData.GetMetadata(moduleType.Module);
             metaData.Types()
-                .Where(t => t.Name != "IfcStrippedOptional")
                 .Should().HaveCount(expectedTypes);
         }
 
         [InlineData(typeof(Xbim.Ifc2x3.EntityFactoryIfc2x3), 771)]
-        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4), 932)]
-        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4x1), 932)]
-        [InlineData(typeof(Xbim.Ifc4x3.EntityFactoryIfc4x3Add2), 1007)]
+        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4), 933)]
+        [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4x1), 933)]
+        [InlineData(typeof(Xbim.Ifc4x3.EntityFactoryIfc4x3Add2), 1008)]
         [Theory]
         public void HasExpectedSchemaTypesByFactory(Type moduleType, int expectedTypes)
         {
@@ -43,7 +42,6 @@ namespace Xbim.Essentials.Tests
             factory.Should().NotBeNull();
             var metaData = ExpressMetaData.GetMetadata(factory);
             metaData.Types()
-                 .Where(t => t.Name != "IfcStrippedOptional")
                 .Should().HaveCount(expectedTypes);
         }
 

--- a/Tests/ExpressMetadataTests.cs
+++ b/Tests/ExpressMetadataTests.cs
@@ -1,9 +1,13 @@
 ﻿using FluentAssertions;
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Xbim.Common;
 using Xbim.Common.Metadata;
+using Xbim.Ifc4;
 using Xunit;
 
 namespace Xbim.Essentials.Tests
@@ -30,7 +34,7 @@ namespace Xbim.Essentials.Tests
         [InlineData(typeof(Xbim.Ifc2x3.EntityFactoryIfc2x3), 771)]
         [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4), 932)]
         [InlineData(typeof(Xbim.Ifc4.EntityFactoryIfc4x1), 932)]
-        [InlineData(typeof(Xbim.Ifc4x3.EntityFactoryIfc4x3Add2), 1008)]
+        [InlineData(typeof(Xbim.Ifc4x3.EntityFactoryIfc4x3Add2), 1007)]
         [Theory]
         public void HasExpectedSchemaTypesByFactory(Type moduleType, int expectedTypes)
         {
@@ -38,7 +42,9 @@ namespace Xbim.Essentials.Tests
             var factory = Activator.CreateInstance(moduleType) as IEntityFactory;
             factory.Should().NotBeNull();
             var metaData = ExpressMetaData.GetMetadata(factory);
-            metaData.Types().Should().HaveCount(expectedTypes);
+            metaData.Types()
+                 .Where(t => t.Name != "IfcStrippedOptional")
+                .Should().HaveCount(expectedTypes);
         }
 
 
@@ -60,7 +66,6 @@ namespace Xbim.Essentials.Tests
             {
                 metaData.Types().Select(t => t.Name).Should().Contain(type.Name);
             }
-
         }
 
         [Fact]

--- a/Xbim.Common/Metadata/ExpressMetaData.cs
+++ b/Xbim.Common/Metadata/ExpressMetaData.cs
@@ -118,10 +118,10 @@ namespace Xbim.Common.Metadata
         private ExpressMetaData(IEntityFactory factory)
         {
             Module = factory.GetType().Module;
-            var schemaNamespace = factory.GetType().Namespace + ".";
+            var schemaNamespace = factory.GetType().Namespace;
             var typesToProcess =
                 Module.GetTypes().Where(
-                    t => IsExpressTypeForSchemaOld(t, schemaNamespace)).ToList();
+                    t => IsExpressTypeForSchema(t, schemaNamespace)).ToList();
 
             _typeIdToExpressTypeLookup = new Dictionary<short, ExpressType>(typesToProcess.Count);
             _typeNameToExpressTypeLookup = new Dictionary<string, ExpressType>(typesToProcess.Count);
@@ -130,16 +130,6 @@ namespace Xbim.Common.Metadata
             _interfaceToExpressTypesLookup = new Dictionary<Type, List<ExpressType>>();
 
             RegisterTypes(typesToProcess);
-        }
-
-        private static bool IsExpressTypeForSchemaOld(Type type, string schemaNamespace = "")
-        {
-            return typeof(IPersist).GetTypeInfo().IsAssignableFrom(type)
-                   && type.IsPublic
-                   && !type.IsEnum && !type.IsInterface
-                   && type.GetCustomAttributes(typeof(ExpressTypeAttribute), false).Any()
-                   && !typeof(IExpressHeaderType).GetTypeInfo().IsAssignableFrom(type)
-                   && (string.IsNullOrEmpty(schemaNamespace) || type.Namespace.StartsWith(schemaNamespace));
         }
         
         internal static bool IsExpressTypeForSchema(Type type, string schemaNamespace = "")

--- a/Xbim.Common/Metadata/ExpressMetaData.cs
+++ b/Xbim.Common/Metadata/ExpressMetaData.cs
@@ -149,27 +149,7 @@ namespace Xbim.Common.Metadata
 
             if(string.IsNullOrWhiteSpace(schemaNamespace))
                 return IsExpressType(type);
-            
-    #if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
-            ReadOnlySpan<char> schemaNs = schemaNamespace.AsSpan().TrimEnd('.');
-            ReadOnlySpan<char> typeNs = type.Namespace.AsSpan();
 
-            // fast exit: prefix ≠ schema
-            if (!typeNs.StartsWith(schemaNs, StringComparison.Ordinal))
-                return false;
-
-            // exact match
-            if (typeNs.Length == schemaNs.Length)
-                return IsExpressType(type);
-
-            // ensure next char is '.'
-            if (typeNs[schemaNs.Length] != '.')
-                return false;
-
-            return IsExpressType(type);
-
-    #else
-            // ---- NETSTANDARD 2.0 fallback 
             string typeNs = type.Namespace;
 
             if (!typeNs.StartsWith(schemaNamespace, StringComparison.Ordinal)) 
@@ -183,7 +163,6 @@ namespace Xbim.Common.Metadata
                 return IsExpressType(type);
 
             return false;
-    #endif
         }
 
        

--- a/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
+++ b/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
@@ -29,4 +29,10 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Tests\ExpressMetadataTests.cs">
+      <Link>ExpressMetadataTests.cs</Link>
+    </Compile>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Previously `IsExpressTypeForSchema` relied on `Namespace.StartsWith(...)`, which meant types in sub-schemas such as **Xbim.Ifc4x3.* ** were mistakenly registered when scanning for **Xbim.Ifc4**. The new logic compares namespaces segment-by-segment.

This treats the dot as a hard boundary, eliminating false positives across merged assemblies while still supporting schemas whose entities live in the root namespace.