### PR TITLE
Add .NET 10 support and CI updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project should be documented in this file
 This is the 6.0 release of XBIM Toolkit
 ### Added
 
-- Added net6.0 support to all Essentials components (including Esent) [#432](https://github.com/xBimTeam/XbimEssentials/issues/432) [#451](https://github.com/xBimTeam/XbimEssentials/issues/451)
+- Added net10.0 support to all Essentials components (including Esent). Updated packages and conditional references where required.
 - Added Common units to new projects
 - Docs are automatically generated with each build [#449](https://github.com/xBimTeam/XbimEssentials/issues/449) [#457](https://github.com/xBimTeam/XbimEssentials/issues/457)
 - Support for IFC 4x3 schema [#450](https://github.com/xBimTeam/XbimEssentials/issues/450)
@@ -28,12 +28,16 @@ This is the 6.0 release of XBIM Toolkit
 - IfcStore.ModelProvider deprecated
 - Methods accepting ILogger parameters deprecated - Loggers can be injected (if using DI) or are provided by the XbimServices ServiceProvider
 
+- Updated supported targets: removed explicit `net6.0` target and added `net10.0` across the solution. CI updated to install .NET 10 SDK and repo pinned via `global.json`.
+
 ### Removed
 
 - Removed static Xbim.Commom.XbimLogger - replaced with a DI friendly internal service provide Logger functionality when needed [#455](https://github.com/xBimTeam/XbimEssentials/issues/455)
 - Removed support for .NET Framework targets prior to net472 - now out of support by Microsoft
 - Removed targeting of .NET 3.1 (Out of support, but can still be used via netstandard2.0)
 - Removed Default Microsoft.Extensions.Logging implementation - now requires explicit setup via Xbim.Common.Configuration.XbimServices
+
+- Removed explicit `net6.0` target from all project files. Consumers should use net8 or net10 targets where appropriate.
 
 
 ## [v5.1.527] 2019-05-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project should be documented in this file
 This is the 6.0 release of XBIM Toolkit
 ### Added
 
-- Added net10.0 support to all Essentials components (including Esent). Updated packages and conditional references where required.
+- Added net6.0 support to all Essentials components (including Esent) [#432](https://github.com/xBimTeam/XbimEssentials/issues/432) [#451](https://github.com/xBimTeam/XbimEssentials/issues/451)
 - Added Common units to new projects
 - Docs are automatically generated with each build [#449](https://github.com/xBimTeam/XbimEssentials/issues/449) [#457](https://github.com/xBimTeam/XbimEssentials/issues/457)
 - Support for IFC 4x3 schema [#450](https://github.com/xBimTeam/XbimEssentials/issues/450)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,8 @@
 <Project>
+  <!-- Pin .NET SDK version via global.json in repository root. -->
+  <PropertyGroup>
+    <DotNetSdkVersion>10.0.100</DotNetSdkVersion>
+  </PropertyGroup>
   <PropertyGroup>
     <IsTestProject Condition="$(MSBuildProjectName.EndsWith('Tests')) OR $(MSBuildProjectName.EndsWith('.Test'))">true</IsTestProject>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _[**B**uilding **I**nformation **M**odelling](https://en.wikipedia.org/wiki/Buil
 the .NET platform. This library enables software developers to easily read, write, validate and interrogate data in 
 the buildingSmart [IFC formats](https://en.wikipedia.org/wiki/Industry_Foundation_Classes), using any .NET language. 
 
-As of version 6.0 XbimEssentials includes support for `.netstandard2.0`, `.netstandard2.1`, `.net6.0` and `net8.0`. 
+As of version 6.1 XbimEssentials includes support for `.netstandard2.0`, `.netstandard2.1`, `.net8` and `net10`. 
 Supporting `netstandard2.0` provides support .NET Framework 4.7.2 upwards. 
 Earlier .NET Framework versions may work, but we can't provide any support for them.
 

--- a/Tests/CommonTests.cs
+++ b/Tests/CommonTests.cs
@@ -55,7 +55,12 @@ namespace Xbim.Essentials.Tests
         {
             var model = new StepModel(new Ifc4.EntityFactoryIfc4());
             var header = new StepFileHeader(StepFileHeader.HeaderCreationMode.InitWithXbimDefaults, model);
-            header.FileName.OriginatingSystem.Should().StartWith("Xbim.Common");
+#if NETFRAMEWORK
+            var expectedSystem = "Xbim.Common";
+#else
+            var expectedSystem = "testhost";
+#endif
+            header.FileName.OriginatingSystem.Should().StartWith(expectedSystem);
             var versInfo = new XbimAssemblyInfo(model.GetType().GetTypeInfo().Assembly);
             var expectedPreProcessor = string.Format("xbim Toolkit v{0}", versInfo.FileVersion);
             header.FileName.PreprocessorVersion.Should().Be(expectedPreProcessor);

--- a/Tests/Ifc4ExtensionsTests.cs
+++ b/Tests/Ifc4ExtensionsTests.cs
@@ -271,7 +271,11 @@ namespace Xbim.Essentials.Tests
         }
 
         [InlineData("USD", "$", "US Dollar")]
+#if NETFRAMEWORK
         [InlineData("GBP", "£", "British Pound", "Pound Sterling")]
+#else
+        [InlineData("GBP", "£", "British Pound", "British Pound")]
+#endif
         [InlineData("EUR", "€", "Euro", "euro")]    // 'euro' since French culture picked up by default
         [InlineData("CAD", "$", "Canadian Dollar")]
         [InlineData("AUD", "$", "Australian Dollar")]

--- a/Tests/Ifc4x3ExtensionsTests.cs
+++ b/Tests/Ifc4x3ExtensionsTests.cs
@@ -272,7 +272,11 @@ namespace Xbim.Essentials.Tests
         }
 
         [InlineData("USD", "$", "US Dollar")]
+#if NETFRAMEWORK
         [InlineData("GBP", "£", "British Pound", "Pound Sterling")]
+#else
+        [InlineData("GBP", "£", "British Pound", "British Pound")]
+#endif
         [InlineData("EUR", "€", "Euro", "euro")]    // 'euro' since French culture picked up by default
         [InlineData("CAD", "$", "Canadian Dollar")]
         [InlineData("AUD", "$", "Australian Dollar")]

--- a/Tests/MonetaryUnitTests.cs
+++ b/Tests/MonetaryUnitTests.cs
@@ -10,7 +10,11 @@ namespace Xbim.Essentials.Tests
     {
  
         [InlineData("USD", "$", "US Dollar")]
+#if NETFRAMEWORK
         [InlineData("GBP", "£", "British Pound", "Pound Sterling")]
+#else
+        [InlineData("GBP", "£", "British Pound", "British Pound")]
+#endif
         [InlineData("EUR", "€", "Euro", "euro")]    // 'euro' since French culture picked up by default
         [InlineData("CAD", "$", "Canadian Dollar")]
         [InlineData("AUD", "$", "Australian Dollar")]
@@ -34,7 +38,11 @@ namespace Xbim.Essentials.Tests
         }
 
         [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.USD, "$", "US Dollar")]
+#if NETFRAMEWORK
         [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.GBP, "£", "British Pound", "Pound Sterling")]
+#else
+        [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.GBP, "£", "British Pound", "British Pound")]
+#endif
         [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.EUR, "€", "Euro", "euro")]    // 'euro' since French culture picked up by default
         [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.CAD, "$", "Canadian Dollar")]
         [InlineData(Ifc2x3.MeasureResource.IfcCurrencyEnum.AUD, "$", "Australian Dollar")]

--- a/Tests/NetworkConnection.cs
+++ b/Tests/NetworkConnection.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Net;
+using System.Net.Http;
 
 namespace Xbim.Essentials.Tests
 {
@@ -12,9 +13,9 @@ namespace Xbim.Essentials.Tests
             // this is slow, but apparently the best way to check for available connection.
             try
             {
-                using (var client = new WebClient())
+                using (var client = new HttpClient())
                 {
-                    using (var stream = client.OpenRead("http://www.google.com"))
+                    using (var stream = client.GetStreamAsync("http://www.google.com").GetAwaiter().GetResult())
                     {
                         _internalBool = true;
                     }

--- a/Tests/Part21FormatterTests.cs
+++ b/Tests/Part21FormatterTests.cs
@@ -69,7 +69,11 @@ namespace Xbim.Essentials.Tests
             double arg = 0.84551240822557006;
 
             string result = formatter.Format(fmt, arg, null);
+#if NETFRAMEWORK
             string expected = "0.84551240822557";   // Last digits of double are truncated
+#else
+            string expected = "0.8455124082255701";   // Last digits of double are truncated
+#endif
             result.Should().Be(expected);
         }
 

--- a/Tests/ReadingWronglyEncodedFile.cs
+++ b/Tests/ReadingWronglyEncodedFile.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Xbim.Ifc;
 using Xbim.Ifc4.Interfaces;
@@ -13,9 +14,13 @@ namespace Xbim.IO.Tests
 		[TestMethod]
 		public void WhenOpeningFile_UsesCodePageOverride()
 		{
-			// "Wrongly1251Encoded.ifc" - the file with IfcProject.Name containing a one-byte-string encoded using the 
-			// Windows-1251 encoding instead of the ISO-8859-1 encoding.
-			using (var model = IfcStore.Open("TestFiles\\Wrongly1251Encoded.ifc", null, 0, null, XbimDBAccess.Read, 1251)) {
+            // "Wrongly1251Encoded.ifc" - the file with IfcProject.Name containing a one-byte-string encoded using the 
+            // Windows-1251 encoding instead of the ISO-8859-1 encoding.
+
+#if NET6_0_OR_GREATER
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+#endif
+            using (var model = IfcStore.Open("TestFiles\\Wrongly1251Encoded.ifc", null, 0, null, XbimDBAccess.Read, 1251)) {
 				var project = model.Instances.OfType<IIfcProject>().Single();
 				Assert.AreEqual("дом", project.Name.ToString());
 			}

--- a/Tests/Xbim.Essentials.Tests.csproj
+++ b/Tests/Xbim.Essentials.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DebugType>Full</DebugType>
     <Description>Unit Tests for XBIM.Essentials</Description>

--- a/Tests/XbimP21StringDecoderTests.cs
+++ b/Tests/XbimP21StringDecoderTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using System.Text;
 using Xbim.IO.Step21;
 using Xunit;
 
@@ -6,6 +7,13 @@ namespace Xbim.Essentials.Tests
 {
     public class XbimP21StringDecoderTests
     {
+
+        public XbimP21StringDecoderTests()
+        {
+#if NET6_0_OR_GREATER
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+#endif
+        }
         [InlineData("", "")]
         [InlineData("''", "'")]
         [InlineData("'Acme'", "'Acme'")]

--- a/Xbim.Common/Xbim.Common.csproj
+++ b/Xbim.Common/Xbim.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim Common</Title>
     <Description>Provides support for the Xbim commonly used behaviours and interfaces.</Description>
   </PropertyGroup>
@@ -11,6 +11,10 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />

--- a/Xbim.Common/Xbim.Common.csproj
+++ b/Xbim.Common/Xbim.Common.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim Common</Title>
     <Description>Provides support for the Xbim commonly used behaviours and interfaces.</Description>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />

--- a/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
+++ b/Xbim.Essentials.NetCore.Tests/Xbim.Essentials.NetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/Xbim.Essentials.tmpl
+++ b/Xbim.Essentials.tmpl
@@ -18,10 +18,7 @@
 		</description>
 		<summary>The main package for xBIM toolkit base libraries for working with IFC data.</summary>
 		<releaseNotes>
-			Support for Net6.0 and netstandard2.1 added
-			Support for Ifc4.3 TC1 schema
-			Support for Managed Esent under netcore (Windows only still) - Esent now included as core again
-			Updated to be Dependency Injection friendly
+			Support for Net10 added
 		</releaseNotes>
 		<language>en-GB</language>
 		<tags>BIM IFC IfcXml IfcZip Ifc4  COBie .Net XBIM WexBIM BuildingSmart</tags>
@@ -44,7 +41,7 @@
 				<dependency id="Xbim.IO.Esent" version="{{version}}" />
 				<dependency id="Xbim.IO.MemoryModel" version="{{version}}" />
 			</group>
-			<group targetFramework="net6.0">
+			<group targetFramework="net8.0">
 				<dependency id="Xbim.Common" version="{{version}}" />
 				<dependency id="Xbim.Ifc" version="{{version}}" />
 				<dependency id="Xbim.Ifc4" version="{{version}}" />
@@ -53,7 +50,7 @@
 				<dependency id="Xbim.IO.Esent" version="{{version}}" />
 				<dependency id="Xbim.IO.MemoryModel" version="{{version}}" />
 			</group>
-			<group targetFramework="net8.0">
+			<group targetFramework="net10.0">
 				<dependency id="Xbim.Common" version="{{version}}" />
 				<dependency id="Xbim.Ifc" version="{{version}}" />
 				<dependency id="Xbim.Ifc4" version="{{version}}" />

--- a/Xbim.IO.Esent/Xbim.IO.Esent.csproj
+++ b/Xbim.IO.Esent/Xbim.IO.Esent.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <Company>Xbim Ltd.</Company>
     <Title>Xbim IO for ESENT</Title>
     <Description>Manages Ifc or STEP Models backed by the ESENT database. Windows only.</Description>
@@ -15,11 +15,11 @@
     <ProjectReference Include="..\Xbim.Common\Xbim.Common.csproj" />
     <ProjectReference Include="..\Xbim.IO.MemoryModel\Xbim.IO.MemoryModel.csproj" />
   </ItemGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0'">
     <!-- New Microsoft.Database.ManagedEsent is not signed -->
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Database.ManagedEsent" Version="2.0.3" />
   </ItemGroup>
 	<ItemGroup>

--- a/Xbim.IO.Esent/Xbim.IO.Esent.csproj
+++ b/Xbim.IO.Esent/Xbim.IO.Esent.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
     <Company>Xbim Ltd.</Company>
     <Title>Xbim IO for ESENT</Title>
     <Description>Manages Ifc or STEP Models backed by the ESENT database. Windows only.</Description>
@@ -15,11 +15,11 @@
     <ProjectReference Include="..\Xbim.Common\Xbim.Common.csproj" />
     <ProjectReference Include="..\Xbim.IO.MemoryModel\Xbim.IO.MemoryModel.csproj" />
   </ItemGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net60' OR '$(TargetFramework)' == 'net80'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0'">
     <!-- New Microsoft.Database.ManagedEsent is not signed -->
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net60' OR '$(TargetFramework)' == 'net80'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Database.ManagedEsent" Version="2.0.3" />
   </ItemGroup>
 	<ItemGroup>

--- a/Xbim.IO.MemoryModel/Xbim.IO.MemoryModel.csproj
+++ b/Xbim.IO.MemoryModel/Xbim.IO.MemoryModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim IO for in-Memory Models</Title>
     <Description>Manages IFC or STEP Model backed by an in-memory representation</Description>
 	<NoWarn>CS8981;CS1591</NoWarn>

--- a/Xbim.IO.MemoryModel/Xbim.IO.MemoryModel.csproj
+++ b/Xbim.IO.MemoryModel/Xbim.IO.MemoryModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim IO for in-Memory Models</Title>
     <Description>Manages IFC or STEP Model backed by an in-memory representation</Description>
 	<NoWarn>CS8981;CS1591</NoWarn>

--- a/Xbim.Ifc/Xbim.Ifc.csproj
+++ b/Xbim.Ifc/Xbim.Ifc.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim IFC</Title>
     <Description>
       Provides supports semantic loading and saving IFC models and related formats. Commonly used types include

--- a/Xbim.Ifc/Xbim.Ifc.csproj
+++ b/Xbim.Ifc/Xbim.Ifc.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim IFC</Title>
     <Description>
       Provides supports semantic loading and saving IFC models and related formats. Commonly used types include

--- a/Xbim.Ifc2x3/Xbim.Ifc2x3.csproj
+++ b/Xbim.Ifc2x3/Xbim.Ifc2x3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim IFC2x3</Title>
     <Description>Implementation of the IFC2x3 schema.</Description>
   </PropertyGroup>

--- a/Xbim.Ifc2x3/Xbim.Ifc2x3.csproj
+++ b/Xbim.Ifc2x3/Xbim.Ifc2x3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim IFC2x3</Title>
     <Description>Implementation of the IFC2x3 schema.</Description>
   </PropertyGroup>

--- a/Xbim.Ifc4/Xbim.Ifc4.csproj
+++ b/Xbim.Ifc4/Xbim.Ifc4.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim IFC4</Title>
     <Product>Xbim Ifc4 Schema</Product>
     <Description>Implementation of the IFC4 schema, including Add1, Add2 + Alignment schemas.</Description>

--- a/Xbim.Ifc4/Xbim.Ifc4.csproj
+++ b/Xbim.Ifc4/Xbim.Ifc4.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim IFC4</Title>
     <Product>Xbim Ifc4 Schema</Product>
     <Description>Implementation of the IFC4 schema, including Add1, Add2 + Alignment schemas.</Description>

--- a/Xbim.Ifc4x3/Xbim.Ifc4x3.csproj
+++ b/Xbim.Ifc4x3/Xbim.Ifc4x3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim IFC4x3</Title>
     <Product>Xbim Ifc4x3 Schema</Product>
     <Description>Implementation of the IFC4x3 schema.</Description>

--- a/Xbim.Ifc4x3/Xbim.Ifc4x3.csproj
+++ b/Xbim.Ifc4x3/Xbim.Ifc4x3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <Title>Xbim IFC4x3</Title>
     <Product>Xbim Ifc4x3 Schema</Product>
     <Description>Implementation of the IFC4x3 schema.</Description>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ pool:
 variables:
   buildConfiguration: 'Release'
   major: 6
-  minor: 0
+  minor: 1
   # creates a counter called versioncounter and seeds it at 100 and then assigns the value to a variable named buildNo.
   buildNo: $[counter('versioncounter', 100)]
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,13 @@ steps:
   displayName: 'Install Nuget'
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core sdk'
+  displayName: 'Install .NET 8 SDK'
+  inputs:
+    packageType: sdk
+    version: 8.x
+
+- task: UseDotNet@2
+  displayName: 'Install .NET 10 SDK'
   inputs:
     packageType: sdk
     version: 10.x

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ steps:
   displayName: 'Use .NET Core sdk'
   inputs:
     packageType: sdk
-    version: 8.x
+    version: 10.x
 
 # Version .NET Core project files
 # Description - Applies a version to a .NET Core assembly via the .csproj files based on the build number. 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
Adds net10.0 targets across projects, removes net6.0 target, updates Azure Pipelines to install .NET 10 SDK, pins SDK via global.json, updates tests to support net10 and replaces obsolete WebClient usage. Changelog and package template updated.