### PR TITLE
Keep the file's own HEADER/FILE_NAME when opening with MemoryModelProvider

### DIFF
--- a/Xbim.Essentials.NetCore.Tests/HeaderFileNameTests.cs
+++ b/Xbim.Essentials.NetCore.Tests/HeaderFileNameTests.cs
@@ -31,6 +31,16 @@ namespace Xbim.Essentials.NetCore.Tests
         }
 
         [Fact]
+        public void MemoryModelProvider_preserves_header_file_name()
+        {
+            var provider = new MemoryModelProvider();
+
+            using var model = provider.Open(TestFile, XbimSchemaVersion.Ifc2X3);
+
+            model.Header.FileName.Name.Should().Be(HeaderFileName);
+        }
+
+        [Fact]
         public void HeuristicModelProvider_preserves_header_file_name()
         {
             var provider = new HeuristicModelProvider();

--- a/Xbim.Essentials.NetCore.Tests/HeaderFileNameTests.cs
+++ b/Xbim.Essentials.NetCore.Tests/HeaderFileNameTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Xbim.Common.Step21;
+using Xbim.Ifc;
+using Xbim.IO.Memory;
+using Xunit;
+
+namespace Xbim.Essentials.NetCore.Tests
+{
+    /// <summary>
+    /// The STEP <c>HEADER</c>/<c>FILE_NAME</c> entry belongs to the file, not to the path it
+    /// happens to be stored under, and it survives opening a model.
+    /// </summary>
+    public class HeaderFileNameTests
+    {
+        // CPM.ifc declares FILE_NAME('0001', ...) in its STEP header, which deliberately
+        // differs from the name the file has on disk.
+        private const string TestFile = @"TestFiles\CPM.ifc";
+        private const string HeaderFileName = "0001";
+
+        public HeaderFileNameTests()
+        {
+            xUnitReinit.Reset();
+        }
+
+        [Fact]
+        public void Step21_parser_reads_header_file_name()
+        {
+            using var model = MemoryModel.OpenRead(TestFile);
+
+            model.Header.FileName.Name.Should().Be(HeaderFileName);
+        }
+
+        [Fact]
+        public void HeuristicModelProvider_preserves_header_file_name()
+        {
+            var provider = new HeuristicModelProvider();
+
+            using var model = provider.Open(TestFile, XbimSchemaVersion.Ifc2X3);
+
+            model.Header.FileName.Name.Should().Be(HeaderFileName);
+        }
+
+        [Fact]
+        public void IfcStore_preserves_header_file_name()
+        {
+            using var store = IfcStore.Open(TestFile);
+
+            store.Header.FileName.Name.Should().Be(HeaderFileName);
+        }
+    }
+}

--- a/Xbim.IO.MemoryModel/MemoryModelProvider.cs
+++ b/Xbim.IO.MemoryModel/MemoryModelProvider.cs
@@ -129,8 +129,14 @@ namespace Xbim.IO.Memory
                         model.LoadXml(path, progDelegate);
                     }
 
-                    FileInfo f = new FileInfo(path);
-                    model.Header.FileName.Name = f.FullName;
+                    if (string.IsNullOrEmpty(model.Header.FileName.Name))
+                    {
+                        // Only fall back to the path on disk when the file itself declares no
+                        // HEADER/FILE_NAME. Historically setting this to the local IFC path is what
+                        // enabled Federations to find their relative child models.
+                        FileInfo f = new FileInfo(path);
+                        model.Header.FileName.Name = f.FullName;
+                    }
                     return model;
                 }
             }


### PR DESCRIPTION
Fixes #638.

## What

`MemoryModelProvider.Open` overwrites `Header.FileName.Name` with the full path of the file it has
just loaded, discarding the `FILE_NAME` the file declares in its own STEP header.

`IfcStore.Open` makes the same assignment, but guards it with `string.IsNullOrEmpty` and the comment
explains why the fallback exists at all: setting it to the local path is what lets federations
resolve their relative child models. The provider runs first, though, so by the time that guard is
evaluated the value is never empty and the intent is already lost.

`HeuristicModelProvider` never touched the header. The value you get back therefore depends on which
provider is registered — the file's own name through Heuristic/Esent, the path on disk through
`MemoryModelProvider`, which is the provider used where Esent is not available.

## Change

The same `IsNullOrEmpty` guard in `MemoryModelProvider.Open`, so the path is used only as a fallback
for files that declare no `FILE_NAME`.

## Tests

`Xbim.Essentials.NetCore.Tests/HeaderFileNameTests.cs`, built on the existing `CPM.ifc` fixture whose
header declares `FILE_NAME('0001', ...)` — deliberately different from the name it has on disk.
Before the change:

```
Expected: "0001"
Actual:   "C:\...\TestFiles\CPM.ifc"
```

Committed in two steps, so each commit is green on its own: first the three cases that already hold
on `develop` (Step21 parser, `HeuristicModelProvider`, `IfcStore`), then the failing
`MemoryModelProvider` case together with the fix.

## Verification

`Xbim.Essentials.NetCore.Tests` — 95/95 on `net8.0`.

`Xbim.Essentials.Tests` shows 30 failures on my machine, but they are unrelated to this change: they
are the culture-sensitive casing problem reported in #670, they reproduce on a clean `develop`, and
this branch neither adds to nor fixes any of them.
