### PR TITLE
Use invariant casing for Express type names (IfcXml is unreadable under Turkish culture)

### DIFF
--- a/Tests/CultureSensitivityTests.cs
+++ b/Tests/CultureSensitivityTests.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+using Xbim.Ifc4;
+using Xbim.IO.Memory;
+using Xunit;
+
+namespace Xbim.Essentials.Tests
+{
+    /// <summary>
+    /// The IfcXml readers resolve element names through <c>string.ToUpper()</c>, which is
+    /// culture sensitive. Under the Turkish (and Azeri) casing rules 'i' uppercases to 'İ',
+    /// so every type name containing an 'i' - i.e. every Ifc type - fails to resolve.
+    /// </summary>
+    public class CultureSensitivityTests
+    {
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("tr-TR")]
+        public void Can_read_ifcxml_regardless_of_current_culture(string culture)
+        {
+            var previous = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+
+                using var model = new MemoryModel(new EntityFactoryIfc4());
+                model.LoadXml(@"TestFiles\Dimensions.ifcxml");
+
+                Assert.True(model.Instances.Count > 0);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = previous;
+            }
+        }
+    }
+}

--- a/Xbim.Common/Step21/Part21Writer.cs
+++ b/Xbim.Common/Step21/Part21Writer.cs
@@ -264,7 +264,7 @@ namespace Xbim.IO.Step21
                 if (realType != propType)
                 //we have a type but it is a select type use the actual value but write out explicitly
                 {
-                    output.Write(realType.Name.ToUpper());
+                    output.Write(realType.Name.ToUpperInvariant());
                     output.Write('(');
                     WriteProperty(realType, propVal, output, map, metadata);
                     output.Write(')');
@@ -359,7 +359,7 @@ namespace Xbim.IO.Step21
             else if (pInfoType == typeof(Int16) || pInfoType == typeof(Int32) || pInfoType == typeof(Int64))
                 output.Write(pVal.ToString());
             else if (pInfoType.GetTypeInfo().IsEnum) //convert enum
-                output.Write(".{0}.", pVal.ToString().ToUpper());
+                output.Write(".{0}.", pVal.ToString().ToUpperInvariant());
             else if (pInfoType == typeof(bool))
             {
                 if (pVal != null)

--- a/Xbim.Common/Step21/StepFileHeader.cs
+++ b/Xbim.Common/Step21/StepFileHeader.cs
@@ -452,7 +452,7 @@ namespace Xbim.Common.Step21
 
         public StepFileSchema(XbimSchemaVersion schemaVersion)
         {
-            _schemas.Add(schemaVersion.ToString().ToUpper());
+            _schemas.Add(schemaVersion.ToString().ToUpperInvariant());
             Init();
         }
 

--- a/Xbim.IO.Esent/IPersistEntityExtensions.cs
+++ b/Xbim.IO.Esent/IPersistEntityExtensions.cs
@@ -191,7 +191,7 @@ namespace Xbim.IO
                 //we have a type but it is a select type use the actual value but write out explicitly
                 {
                     entityWriter.Write(Convert.ToByte(P21ParseAction.BeginNestedType));
-                    entityWriter.Write(realType.Name.ToUpper());
+                    entityWriter.Write(realType.Name.ToUpperInvariant());
                     entityWriter.Write(Convert.ToByte(P21ParseAction.BeginList));
                     WriteProperty(realType, propVal, entityWriter, metadata);
                     entityWriter.Write(Convert.ToByte(P21ParseAction.EndList));

--- a/Xbim.IO.MemoryModel/Xml/IfcXmlWriter3.cs
+++ b/Xbim.IO.MemoryModel/Xml/IfcXmlWriter3.cs
@@ -328,7 +328,7 @@ namespace Xbim.IO.Xml
                     }
                     else
                         output.WriteStartElement(propName);
-                    output.WriteValue(propVal.ToString().ToLower());
+                    output.WriteValue(propVal.ToString().ToLowerInvariant());
                 }
                 else if (pInfoType.GetTypeInfo().UnderlyingSystemType == typeof(Boolean))
                 {

--- a/Xbim.IO.MemoryModel/Xml/XbimXmlReader3.cs
+++ b/Xbim.IO.MemoryModel/Xml/XbimXmlReader3.cs
@@ -394,7 +394,7 @@ namespace Xbim.IO.Xml
         {
             ExpressType expressType;
             var xmlEntity = _currentNode as XmlEntity;
-            if (xmlEntity != null && !_metadata.TryGetExpressType(elementName.ToUpper(), out expressType))
+            if (xmlEntity != null && !_metadata.TryGetExpressType(elementName.ToUpperInvariant(), out expressType))
             {
                 var t = _metadata.ExpressType(xmlEntity.Entity);
 
@@ -423,14 +423,14 @@ namespace Xbim.IO.Xml
 
         private bool IsIfcType(string elementName, out ExpressType expressType)
         {
-            var ok = _metadata.TryGetExpressType(elementName.ToUpper(), out expressType);
+            var ok = _metadata.TryGetExpressType(elementName.ToUpperInvariant(), out expressType);
             if (!ok)
             {
 
                 if (elementName.Contains("-wrapper") && elementName.StartsWith(_expressNamespace) == false) // we have an inline type definition
                 {
                     var inputName = elementName.Substring(0, elementName.LastIndexOf("-", StringComparison.Ordinal));
-                    ok = _metadata.TryGetExpressType(inputName.ToUpper(), out expressType);
+                    ok = _metadata.TryGetExpressType(inputName.ToUpperInvariant(), out expressType);
                 }
             }
             return ok && typeof(IExpressValueType).GetTypeInfo().IsAssignableFrom(expressType.Type);
@@ -477,7 +477,7 @@ namespace Xbim.IO.Xml
 
         private bool IsIfcEntity(string elementName, out ExpressType expressType)
         {
-            return _metadata.TryGetExpressType(elementName.ToUpper(), out expressType);
+            return _metadata.TryGetExpressType(elementName.ToUpperInvariant(), out expressType);
         }
 
         private void EndElement(XmlReader input, XmlNodeType prevInputType, string prevInputName, out IPersistEntity writeEntity)

--- a/Xbim.IO.MemoryModel/Xml/XbimXmlReader4.cs
+++ b/Xbim.IO.MemoryModel/Xml/XbimXmlReader4.cs
@@ -215,12 +215,12 @@ namespace Xbim.IO.Xml
         private ExpressType GetExpresType(XmlReader input)
         {
             //type defined by xml attribute has always a priority over the name of the element
-            var typeName = (input.GetAttribute("type", _xsi) ?? input.LocalName).ToUpper();
+            var typeName = (input.GetAttribute("type", _xsi) ?? input.LocalName).ToUpperInvariant();
             if (_metadata.TryGetExpressType(typeName, out ExpressType expType))
                 return expType;
 
             //try to replace WRAPPER keyword
-            typeName = input.LocalName.ToUpper();
+            typeName = input.LocalName.ToUpperInvariant();
             if (!typeName.Contains("-")) return null;
 
             typeName = typeName.Replace("-WRAPPER", "");

--- a/Xbim.IO.MemoryModel/Xml/XbimXmlWriter4.cs
+++ b/Xbim.IO.MemoryModel/Xml/XbimXmlWriter4.cs
@@ -342,7 +342,7 @@ namespace Xbim.IO.Xml
                 if (pInfoType.GetTypeInfo().IsEnum) //convert enum
                 {
                     output.WriteStartElement(propName);
-                    pValue = propVal.ToString().ToLower();
+                    pValue = propVal.ToString().ToLowerInvariant();
                 }
                 else if (pInfoType.GetTypeInfo().UnderlyingSystemType == typeof(Boolean))
                 {


### PR DESCRIPTION
Fixes #670.

## What

Express type names are resolved by upper-casing the XML element name with the culture-sensitive
`string.ToUpper()`, while the metadata dictionary is keyed on invariant upper case. Turkish and Azeri
casing map `i` to `İ` (U+0130), so the lookup never matches:

```
tr-TR      "IfcOrganization".ToUpper()          => "IFCORGANİZATİON"
invariant  "IfcOrganization".ToUpperInvariant() => "IFCORGANIZATION"
```

Every IFC type name contains an `i`, so on a host whose current culture is Turkish, reading IfcXml
fails completely. The write side has the same problem in the other direction: select type names, enum
values and the schema name in the STEP header are cased with the current culture, so such a host
writes names that no reader can resolve.

CI does not see any of this because it runs under an English culture.

## Changes

Two commits, split by direction so each stands on its own:

1. **Readers** (`XbimXmlReader3`, `XbimXmlReader4`) — invariant casing for the type-name lookups,
   plus a culture-parameterised regression test in `Tests/CultureSensitivityTests.cs`. `en-US` passed
   before this change; `tr-TR` threw `XbimParserException`.
2. **Writers** (`XbimXmlWriter4`, `IfcXmlWriter3`, `Part21Writer`, `StepFileHeader`,
   `IPersistEntityExtensions`) — the same treatment for the names and enum values written out.

12 changed lines across 6 files. No public API change, and no behaviour change under an invariant or
English culture — `ToUpperInvariant()` and `ToUpper()` agree there.

## Verification

On a `tr-TR` machine, `Xbim.Essentials.Tests` goes from **30 failures to 497/497**, on both `net48`
and `net10.0`. `Xbim.Essentials.NetCore.Tests` is green throughout.

## Scope

There are other culture-sensitive `ToUpper()` / `ToLower()` calls in the tree — in exception message
formatting and in generated schema code — which I have deliberately left alone: they do not affect
parsing or serialization, and sweeping them would make this diff much harder to review. Happy to
follow up separately if you would like them cleaned up too.

Independent of #671, which touches `MemoryModelProvider` only; the two branches share no files.
